### PR TITLE
mixed_group addition and biblatex_include fix

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -380,7 +380,7 @@ module.exports = grammar({
         field('command', '\\addbibresource'),
         field('option', optional($.key_val_options)),
         '{',
-        sepBy(field('path', $.path), ','),
+        field('path', $.path),
         '}'
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -239,9 +239,9 @@ module.exports = grammar({
 
     mixed_group: $ =>
       seq(
-        field('left', choice('(', '[')),
+        field('left', choice('(', '[', '\\{')),
         field('child', repeat($._content)),
-        field('right', choice(')', ']'))
+        field('right', choice(')', ']', '\\}'))
       ),
 
     key_val_options: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1961,45 +1961,12 @@
           "value": "{"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "path",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "path"
-                  }
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "FIELD",
-                        "name": "path",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "path"
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "path"
+          }
         },
         {
           "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -851,6 +851,10 @@
               {
                 "type": "STRING",
                 "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "\\{"
               }
             ]
           }
@@ -879,6 +883,10 @@
               {
                 "type": "STRING",
                 "value": "]"
+              },
+              {
+                "type": "STRING",
+                "value": "\\}"
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -310,8 +310,8 @@
         ]
       },
       "path": {
-        "multiple": true,
-        "required": false,
+        "multiple": false,
+        "required": true,
         "types": [
           {
             "type": "path",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3795,6 +3795,10 @@
           {
             "type": "[",
             "named": false
+          },
+          {
+            "type": "\\{",
+            "named": false
           }
         ]
       },
@@ -3804,6 +3808,10 @@
         "types": [
           {
             "type": ")",
+            "named": false
+          },
+          {
+            "type": "\\}",
             "named": false
           },
           {
@@ -6187,6 +6195,14 @@
   },
   {
     "type": "\\vref",
+    "named": false
+  },
+  {
+    "type": "\\{",
+    "named": false
+  },
+  {
+    "type": "\\}",
     "named": false
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
Added `\{` and `\}` to mixed_group category so that something like `\{ somemath \}` would not be parsed as generic_command -> text -> generic_command.

Also removed the sepBy-comma from biblatex_include because the command `\addbibresource` actually only takes one file as input. When trying to compile a file with `\addbibresource{file1.bib,file2.bib}` written in it LaTeX will throw an error that looks something like `Bibliography file 'file1.bib,file2.bib' does not exist`.