### PR TITLE
Add additional KOMA-Script sectioning commands to the grammar.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,7 @@ module.exports = grammar({
     part: $ =>
       prec.right(
         seq(
-          field('command', choice('\\part', '\\part*')),
+          field('command', choice('\\part', '\\part*', '\\addpart', '\\addpart*')),
           field('text', $.brace_group),
           field(
             'child',
@@ -105,7 +105,7 @@ module.exports = grammar({
     chapter: $ =>
       prec.right(
         seq(
-          field('command', choice('\\chapter', '\\chapter*')),
+          field('command', choice('\\chapter', '\\chapter*', '\\addchap', '\\addchap*')),
           field('text', $.brace_group),
           field(
             'child',
@@ -127,7 +127,7 @@ module.exports = grammar({
     section: $ =>
       prec.right(
         seq(
-          field('command', choice('\\section', '\\section*')),
+          field('command', choice('\\section', '\\section*', '\\addsec', '\\addsec*')),
           field('text', $.brace_group),
           field(
             'child',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -234,6 +234,14 @@
                 {
                   "type": "STRING",
                   "value": "\\part*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addpart"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addpart*"
                 }
               ]
             }
@@ -312,6 +320,14 @@
                 {
                   "type": "STRING",
                   "value": "\\chapter*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addchap"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addchap*"
                 }
               ]
             }
@@ -386,6 +402,14 @@
                 {
                   "type": "STRING",
                   "value": "\\section*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addsec"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addsec*"
                 }
               ]
             }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1006,6 +1006,14 @@
         "required": true,
         "types": [
           {
+            "type": "\\addchap",
+            "named": false
+          },
+          {
+            "type": "\\addchap*",
+            "named": false
+          },
+          {
             "type": "\\chapter",
             "named": false
           },
@@ -4253,6 +4261,14 @@
         "required": true,
         "types": [
           {
+            "type": "\\addpart",
+            "named": false
+          },
+          {
+            "type": "\\addpart*",
+            "named": false
+          },
+          {
             "type": "\\part",
             "named": false
           },
@@ -4486,6 +4502,14 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "\\addsec",
+            "named": false
+          },
+          {
+            "type": "\\addsec*",
+            "named": false
+          },
           {
             "type": "\\section",
             "named": false
@@ -5671,6 +5695,30 @@
   },
   {
     "type": "\\addbibresource",
+    "named": false
+  },
+  {
+    "type": "\\addchap",
+    "named": false
+  },
+  {
+    "type": "\\addchap*",
+    "named": false
+  },
+  {
+    "type": "\\addpart",
+    "named": false
+  },
+  {
+    "type": "\\addpart*",
+    "named": false
+  },
+  {
+    "type": "\\addsec",
+    "named": false
+  },
+  {
+    "type": "\\addsec*",
     "named": false
   },
   {


### PR DESCRIPTION
Implements #21.

With these changes, the example from #21 looks as follows instead.
```shell
$ tree-sitter parse test.tex
(document [0, 0] - [6, 0]
  (environment [0, 0] - [5, 14]
    begin: (begin [0, 0] - [0, 16]
      name: (word [0, 7] - [0, 15]))
    child: (chapter [1, 0] - [1, 10]
      text: (brace_group [1, 8] - [1, 10]))
    child: (chapter [2, 0] - [2, 11]
      text: (brace_group [2, 9] - [2, 11]))
    child: (chapter [3, 0] - [3, 10]
      text: (brace_group [3, 8] - [3, 10]))
    child: (chapter [4, 0] - [4, 11]
      text: (brace_group [4, 9] - [4, 11]))
    end: (end [5, 0] - [5, 14]
      name: (word [5, 5] - [5, 13]))))
```
This is the correct tree for the example.