### PR TITLE
Change precedence for _section rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -111,7 +111,7 @@ module.exports = grammar({
 
     part: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field(
             'command',
@@ -137,7 +137,7 @@ module.exports = grammar({
 
     chapter: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field(
             'command',
@@ -162,7 +162,7 @@ module.exports = grammar({
 
     section: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field(
             'command',
@@ -186,7 +186,7 @@ module.exports = grammar({
 
     subsection: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field('command', choice('\\subsection', '\\subsection*')),
           field('text', optional($.curly_group)),
@@ -206,7 +206,7 @@ module.exports = grammar({
 
     subsubsection: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field('command', choice('\\subsubsection', '\\subsubsection*')),
           field('text', optional($.curly_group)),
@@ -225,7 +225,7 @@ module.exports = grammar({
 
     paragraph: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field('command', choice('\\paragraph', '\\paragraph*')),
           field('text', optional($.curly_group)),
@@ -238,7 +238,7 @@ module.exports = grammar({
 
     subparagraph: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field('command', choice('\\subparagraph', '\\subparagraph*')),
           field('text', optional($.curly_group)),
@@ -249,7 +249,7 @@ module.exports = grammar({
 
     enum_item: $ =>
       prec.right(
-        1,
+        -1,
         seq(
           field('command', choice('\\item', '\\item*')),
           field('label', optional($.brack_group_text)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -366,7 +366,7 @@
     },
     "part": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -489,7 +489,7 @@
     },
     "chapter": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -605,7 +605,7 @@
     },
     "section": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -714,7 +714,7 @@
     },
     "subsection": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -808,7 +808,7 @@
     },
     "subsubsection": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -895,7 +895,7 @@
     },
     "paragraph": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -975,7 +975,7 @@
     },
     "subparagraph": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1048,7 +1048,7 @@
     },
     "enum_item": {
       "type": "PREC_RIGHT",
-      "value": 1,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [

--- a/test/corpus/issues.txt
+++ b/test/corpus/issues.txt
@@ -330,3 +330,50 @@ tree-sitter-latex (Issue #24)
     (brack_group_text
       (text
         (word)))))
+
+================================================================================
+tree-sitter-latex (Issue #25 Nesting of document structure)
+================================================================================
+
+\section{SomeSection}
+
+1
+
+\begin{itemize}
+
+    \item 2 \texttt{3} 4
+
+\end{itemize}
+
+5
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (curly_group
+      (text
+        (word)))
+    (text
+      (word))
+    (generic_environment
+      (begin
+        (curly_group_text
+          (text
+            (word))))
+      (enum_item
+        (text
+          (word))
+        (command
+          (command_name)
+          (curly_group
+            (text
+              (word))))
+        (text
+          (word)))
+      (end
+        (curly_group_text
+          (text
+            (word)))))
+    (text
+      (word))))


### PR DESCRIPTION
Fixes #25.
The current grammar handles the otherwise existing conflict by giving the `_section` related rules a higher precedence than the other rules (default precedence is 0).
From my intuition, the parser therewith prefers to prematurely "close" the respective document structure when ambiguity arises. 
But instead, the opposite behaviour is needed. The document structure should be "kept open" (ie on the parsing stack) by giving it a lower precedence.

