### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ Cargo.lock
 build/
 /bindings/c/*.h
 /bindings/c/tree-sitter-*.pc
+
+# Swift Package Manager
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -2,35 +2,35 @@
 import PackageDescription
 
 let package = Package(
-	name: "TreeSitterLatex",
-	products: [
-		.library(name: "TreeSitterLatex", targets: ["TreeSitterLatex"]),
-	],
-	dependencies: [],
-	targets: [
-		.target(name: "TreeSitterLatex",
-				path: ".",
-				exclude: [
-					"binding.gyp",
-					"bindings",
-					"benches",
-					".github",
-					"examples",
-					"Cargo.toml",
-					"test",
-					"grammar.js",
-					"LICENSE",
-					"Makefile",
-					"package.json",
-					"README.md",
-					"src/grammar.json",
-					"src/node-types.json",
-				],
-				sources: [
-					"src/parser.c",
-					"src/scanner.c",
-				],
-				publicHeadersPath: "bindings/swift",
-				cSettings: [.headerSearchPath("src")])
-	]
+    name: "TreeSitterLatex",
+    products: [
+        .library(name: "TreeSitterLatex", targets: ["TreeSitterLatex"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterLatex",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "benches",
+                    ".github",
+                    "examples",
+                    "Cargo.toml",
+                    "test",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.c",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+	name: "TreeSitterLatex",
+	products: [
+		.library(name: "TreeSitterLatex", targets: ["TreeSitterLatex"]),
+	],
+	dependencies: [],
+	targets: [
+		.target(name: "TreeSitterLatex",
+				path: ".",
+				exclude: [
+					"binding.gyp",
+					"bindings",
+					"benches",
+					".github",
+					"examples",
+					"Cargo.toml",
+					"test",
+					"grammar.js",
+					"LICENSE",
+					"Makefile",
+					"package.json",
+					"README.md",
+					"src/grammar.json",
+					"src/node-types.json",
+				],
+				sources: [
+					"src/parser.c",
+					"src/scanner.c",
+				],
+				publicHeadersPath: "bindings/swift",
+				cSettings: [.headerSearchPath("src")])
+	]
+)

--- a/bindings/swift/TreeSitterLatex/latex.h
+++ b/bindings/swift/TreeSitterLatex/latex.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_LATEX_H_
+#define TREE_SITTER_LATEX_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_latex();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_LATEX_H_


### PR DESCRIPTION
This pull request is intended to add Swift Package Manager support so that we can use this package with the wonderful https://github.com/ChimeHQ/SwiftTreeSitter without manually adding another build step to our Swift projects.

As an example, here's how it would be used:

1. Add this package as a dependency to your Xcode project or `Package.swift` file.
2. Use it as follows:
    ```swift
    import SwiftTreeSitter
    import TreeSitterSwift
    
    let language = Language(language: tree_sitter_latex())
    let parser = Parser()
    try parser.setLanguage(language)
    
    let source = "" // Insert LaTeX source code here
    let tree = parser.parse(source)!
    // Use the tree as you see fit!
    ```

The work for this PR is based on tree-sitter/tree-sitter-java#113. I've tested it with the included test document and a few LaTeX documents I've written myself and it worked perfectly.