### PR TITLE
Stop treating \big, \bigg, \Big, \Bigg delimiters as pairable

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -861,10 +861,6 @@ module.exports = grammar({
             'left_command',
             choice(
               '\\left',
-              '\\big',
-              '\\Big',
-              '\\bigg',
-              '\\Bigg',
               '\\bigl',
               '\\Bigl',
               '\\biggl',
@@ -877,10 +873,6 @@ module.exports = grammar({
             'right_command',
             choice(
               '\\right',
-              '\\big',
-              '\\Big',
-              '\\bigg',
-              '\\Bigg',
               '\\bigr',
               '\\Bigr',
               '\\biggr',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4359,22 +4359,6 @@
                 },
                 {
                   "type": "STRING",
-                  "value": "\\big"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\Big"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\bigg"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\Bigg"
-                },
-                {
-                  "type": "STRING",
                   "value": "\\bigl"
                 },
                 {
@@ -4416,22 +4400,6 @@
                 {
                   "type": "STRING",
                   "value": "\\right"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\big"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\Big"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\bigg"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\Bigg"
                 },
                 {
                   "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3978,27 +3978,11 @@
         "required": true,
         "types": [
           {
-            "type": "\\Big",
-            "named": false
-          },
-          {
-            "type": "\\Bigg",
-            "named": false
-          },
-          {
             "type": "\\Biggl",
             "named": false
           },
           {
             "type": "\\Bigl",
-            "named": false
-          },
-          {
-            "type": "\\big",
-            "named": false
-          },
-          {
-            "type": "\\bigg",
             "named": false
           },
           {
@@ -4054,27 +4038,11 @@
         "required": true,
         "types": [
           {
-            "type": "\\Big",
-            "named": false
-          },
-          {
-            "type": "\\Bigg",
-            "named": false
-          },
-          {
             "type": "\\Biggr",
             "named": false
           },
           {
             "type": "\\Bigr",
-            "named": false
-          },
-          {
-            "type": "\\big",
-            "named": false
-          },
-          {
-            "type": "\\bigg",
             "named": false
           },
           {
@@ -7471,14 +7439,6 @@
     "named": false
   },
   {
-    "type": "\\Big",
-    "named": false
-  },
-  {
-    "type": "\\Bigg",
-    "named": false
-  },
-  {
     "type": "\\Biggl",
     "named": false
   },
@@ -7896,14 +7856,6 @@
   },
   {
     "type": "\\bibliography",
-    "named": false
-  },
-  {
-    "type": "\\big",
-    "named": false
-  },
-  {
-    "type": "\\bigg",
     "named": false
   },
   {

--- a/test/corpus/issues.txt
+++ b/test/corpus/issues.txt
@@ -726,14 +726,13 @@ tree-sitter-latex (Issue #55) | minted with options
           (word))))))
 
 ================================================================================
-tree-sitter-latex (Issue #58) | math delimiters
+tree-sitter-latex (Issues #58 and #84) | math delimiters
 ================================================================================
 
-\big( 2 + 2 \big)
 \bigl( 2 + 2 \bigr)
 \left( 2 + 2 \right)
-\big\langle 2 + 2 \big\rangle
 \bigl| v \bigr|
+r \big|_0^a
 
 --------------------------------------------------------------------------------
 
@@ -750,16 +749,13 @@ tree-sitter-latex (Issue #58) | math delimiters
       (word)))
   (math_delimiter
     (text
-      (word)
-      (operator)
       (word)))
-  (math_delimiter
-    (command_name)
-    (text
-      (word)
-      (operator)
+  (text
+    (word)
+    (generic_command
+      (command_name))
+    (operator)
+    (subscript
       (word))
-    (command_name))
-  (math_delimiter
-    (text
+    (superscript
       (word))))


### PR DESCRIPTION
Delimiters preceded by these commands are treated by TeX as Ord atoms -- meaning they don't require any sort of pairing, and shouldn't be treated as such.

See #84 and The TeXbook, page 171.