### PR TITLE
fix: Allow optional argument for \author

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -621,6 +621,7 @@ module.exports = grammar({
     author_declaration: $ =>
       seq(
         field('command', '\\author'),
+        field('options', optional($.brack_group)),
         field('authors', $.curly_group_author_list)
       ),
 


### PR DESCRIPTION
Many classes (e.g. AMS) expect the short author name as an optional argument to `\author`.