### PR TITLE
fix: add "math" as math_environment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -536,6 +536,7 @@ module.exports = grammar({
     ...specialEnvironment({
       rule: 'math_environment',
       name: choice(
+        'math',
         'displaymath',
         'displaymath*',
         'equation',


### PR DESCRIPTION
The `math` environment, which is available by default (even in
`\documentclass{standalone}`), produces inline math similar to `\(\)`. There
does not appear to exist a `math*` environment (at least by default, anyway).
