### PR TITLE
Support more general URIs in hyperlinks (#134)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -323,6 +323,8 @@ module.exports = grammar({
     curly_group_path_list: $ =>
       seq('{', sepBy(field('path', $.path), ','), '}'),
 
+    curly_group_uri: $ => seq('{', field('uri', $.uri), '}'),
+
     curly_group_command_name: $ =>
       seq('{', field('command', $.command_name), '}'),
 
@@ -380,6 +382,8 @@ module.exports = grammar({
     placeholder: $ => /#\d/,
 
     path: $ => /[^\*\"\[\]:;,\|\{\}<>]+/,
+
+    uri: $ => /[^\[\]\{\}]+/,
 
     argc: $ => /\d/,
 
@@ -1120,7 +1124,7 @@ module.exports = grammar({
       prec.right(
         seq(
           field('command', choice('\\url', '\\href')),
-          field('url', $.curly_group_text),
+          field('uri', $.curly_group_uri),
           field('label', optional($.curly_group)),
         ),
       ),

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -183,47 +183,38 @@ Hyperlinks
 
 \href{https://github.com/latex-lsp/tree-sitter-latex}{tree-sitter-latex}
 
+\href{https://github.com/latex-lsp/tree-sitter-latex/issues?q=hyperlink}
+                                                          {search ``hyperlink''}
+
+\href{file:///path/to/file_containing spaces, and also commas}{file URI}
+
 --------------------------------------------------------------------------------
 
 (source_file
   (hyperlink
-    (curly_group_text
-      (text
-        (word)
-        (operator)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word))))
+    (curly_group_uri
+      (uri)))
   (hyperlink
-    (curly_group_text
-      (text
-        (word)
-        (operator)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)
-        (operator)
-        (word)))
+    (curly_group_uri
+      (uri))
     (curly_group
       (text
         (word)
         (operator)
         (word)
         (operator)
+        (word))))
+  (hyperlink
+    (curly_group_uri
+      (uri))
+    (curly_group
+      (text
+        (word)
+        (word))))
+  (hyperlink
+    (curly_group_uri
+      (uri))
+    (curly_group
+      (text
+        (word)
         (word)))))


### PR DESCRIPTION
Fixes #134.

I am not sure if this parsing of URIs is sufficient/adequate, but seems to work alright.