### PR TITLE
Fix including grammar.json in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -521,7 +521,5 @@ build/
 /bindings/c/*.h
 /bindings/c/tree-sitter-*.pc
 
-src/
-!src/scanner.c
-!src/grammar.json
-!src/node-types.json
+src/parser.c
+src/tree_sitter/

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -4,6 +4,9 @@ fn main() {
     let mut c_config = cc::Build::new();
     c_config.std("c11").include(src_dir);
 
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,0 +1,5914 @@
+{
+  "name": "latex",
+  "word": "command_name",
+  "rules": {
+    "source_file": {
+      "type": "REPEAT",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_root_content"
+      }
+    },
+    "_whitespace": {
+      "type": "PATTERN",
+      "value": "\\s+"
+    },
+    "line_comment": {
+      "type": "PATTERN",
+      "value": "%[^\\r\\n]*"
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "STRING",
+            "value": "\\iffalse"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "comment",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_trivia_raw_fi"
+                },
+                "named": true,
+                "value": "comment"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\fi"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "_root_content": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_section"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_paragraph"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_flat_content"
+        }
+      ]
+    },
+    "_flat_content": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_text_with_env_content"
+          },
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "_text_with_env_content": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "verbatim_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "listing_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "minted_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pycode_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sagesilent_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sageblock_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generic_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_environment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_text_content"
+        }
+      ]
+    },
+    "_text_content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "block_comment"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_command"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "text"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "displayed_equation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "inline_formula"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "math_delimiter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "text_mode"
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
+    },
+    "_section": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "part"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "chapter"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "section"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subsection"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subsubsection"
+            }
+          }
+        ]
+      }
+    },
+    "_paragraph": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "paragraph"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subparagraph"
+            }
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "enum_item"
+            }
+          }
+        ]
+      }
+    },
+    "_section_part": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "toc",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "_part_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\part"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\part*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addpart"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addpart*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "part": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_part_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": -1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_paragraph"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "chapter"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "section"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsection"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsubsection"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_chapter_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\chapter"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\chapter*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addchap"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addchap*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "chapter": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_chapter_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": -1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_paragraph"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "section"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsection"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsubsection"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_section_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\section"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\section*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addsec"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\addsec*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "section": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_section_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": -1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_paragraph"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsection"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subsubsection"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_subsection_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\subsection"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\subsection*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "subsection": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_subsection_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": -1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_paragraph"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "subsubsection"
+                  }
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_subsubsection_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\subsubsection"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\subsubsection*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "subsubsection": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_subsubsection_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": -1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_paragraph"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_paragraph_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\paragraph"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\paragraph*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "paragraph": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_paragraph_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "subparagraph"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "enum_item"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_subparagraph_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\subparagraph"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\subparagraph*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_section_part"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "subparagraph": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_subparagraph_declaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "enum_item"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_enum_itemdeclaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\item"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\item*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "label",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "brack_group_text"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "enum_item": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_enum_itemdeclaration"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_flat_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": []
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "curly_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_root_content"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_text": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "SYMBOL",
+            "name": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_text_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "text",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "text"
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "text",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "text"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_path": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "path"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_path_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "path",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "path"
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "path",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "path"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_uri": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "uri",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uri"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_command_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "SYMBOL",
+            "name": "command_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_key_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "pair",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "key_value_pair"
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "pair",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "key_value_pair"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_glob_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "SYMBOL",
+            "name": "glob_pattern"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_impl": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_text_content"
+              },
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "STRING",
+                "value": "="
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_author_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "REPEAT1",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_text_content"
+                    }
+                  },
+                  "named": true,
+                  "value": "author"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "STRING",
+                          "value": "\\and"
+                        },
+                        "named": true,
+                        "value": "command_name"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "REPEAT1",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_text_content"
+                          }
+                        },
+                        "named": true,
+                        "value": "author"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "brack_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_text_with_env_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "brack_group_text": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "SYMBOL",
+            "name": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "brack_group_argc": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "argc"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "brack_group_key_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "pair",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "key_value_pair"
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "pair",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "key_value_pair"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "text": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "operator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "word"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "placeholder"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "block_comment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_command"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "superscript"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "subscript"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "word": {
+      "type": "PATTERN",
+      "value": "[^\\s\\\\%\\{\\},\\$\\[\\]\\(\\)=\\#_\\^\\-\\+\\/\\*]+"
+    },
+    "placeholder": {
+      "type": "PATTERN",
+      "value": "#\\d"
+    },
+    "path": {
+      "type": "PATTERN",
+      "value": "[^\\*\\\"\\[\\]:;,\\|\\{\\}<>]+"
+    },
+    "uri": {
+      "type": "PATTERN",
+      "value": "[^\\[\\]\\{\\}]+"
+    },
+    "argc": {
+      "type": "PATTERN",
+      "value": "\\d"
+    },
+    "glob_pattern": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_glob_pattern_fragment"
+      }
+    },
+    "_glob_pattern_fragment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_glob_pattern_fragment"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        },
+        {
+          "type": "PATTERN",
+          "value": "[^\\\"\\[\\]:;\\|\\{\\}<>]+"
+        }
+      ]
+    },
+    "operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "STRING",
+          "value": "'"
+        }
+      ]
+    },
+    "letter": {
+      "type": "PATTERN",
+      "value": "[^\\\\%\\{\\}\\$\\#_\\^]"
+    },
+    "subscript": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "_"
+        },
+        {
+          "type": "FIELD",
+          "name": "subscript",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "letter"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_name"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "superscript": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "FIELD",
+          "name": "superscript",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "letter"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_name"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "key_value_pair": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "key",
+          "content": {
+            "type": "SYMBOL",
+            "name": "text"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "value"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "value": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_text_content"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "brack_group"
+          }
+        ]
+      }
+    },
+    "displayed_equation": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "$$"
+              },
+              {
+                "type": "STRING",
+                "value": "\\["
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_root_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "$$"
+              },
+              {
+                "type": "STRING",
+                "value": "\\]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "inline_formula": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "$"
+              },
+              {
+                "type": "STRING",
+                "value": "\\("
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_root_content"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "$"
+              },
+              {
+                "type": "STRING",
+                "value": "\\)"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "begin": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "STRING",
+              "value": "\\begin"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_text"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "options",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "brack_group"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "end": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "STRING",
+              "value": "\\end"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_text"
+            }
+          }
+        ]
+      }
+    },
+    "generic_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "SYMBOL",
+            "name": "begin"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_root_content"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "SYMBOL",
+            "name": "end"
+          }
+        }
+      ]
+    },
+    "comment_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_comment_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "comment",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_comment"
+            },
+            "named": true,
+            "value": "comment"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_comment_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_comment_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_comment_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_comment_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_comment_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_comment_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_comment_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_comment_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "comment"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "verbatim_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_verbatim_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "verbatim",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_verbatim"
+            },
+            "named": true,
+            "value": "comment"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_verbatim_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_verbatim_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_verbatim_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_verbatim_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_verbatim_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_verbatim_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_verbatim_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_verbatim_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "verbatim"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "listing_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_listing_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "code",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_listing"
+            },
+            "named": true,
+            "value": "source_code"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_listing_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_listing_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_listing_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_listing_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_listing_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_listing_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_listing_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_listing_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "lstlisting"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "minted_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_minted_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "code",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_minted"
+            },
+            "named": true,
+            "value": "source_code"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_minted_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_minted_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_minted_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "options",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "brack_group_key_value"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "language",
+              "content": {
+                "type": "SYMBOL",
+                "name": "curly_group_text"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "_minted_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_minted_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_minted_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_minted_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_minted_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "minted"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "pycode_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pycode_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "code",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_pycode"
+            },
+            "named": true,
+            "value": "source_code"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pycode_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_pycode_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pycode_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_pycode_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pycode_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_pycode_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pycode_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_pycode_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "pycode"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "sagesilent_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sagesilent_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "code",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_sagesilent"
+            },
+            "named": true,
+            "value": "source_code"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sagesilent_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_sagesilent_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sagesilent_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_sagesilent_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sagesilent_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_sagesilent_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sagesilent_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_sagesilent_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "sagesilent"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "sageblock_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sageblock_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "code",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_trivia_raw_env_sageblock"
+            },
+            "named": true,
+            "value": "source_code"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sageblock_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_sageblock_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sageblock_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_sageblock_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sageblock_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_sageblock_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_sageblock_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_sageblock_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "sageblock"
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "math_environment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_environment_begin"
+            },
+            "named": true,
+            "value": "begin"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_flat_content"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_environment_end"
+            },
+            "named": true,
+            "value": "end"
+          }
+        }
+      ]
+    },
+    "_math_environment_begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\begin"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": []
+        }
+      ]
+    },
+    "_math_environment_end": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\end"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_environment_group"
+            },
+            "named": true,
+            "value": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "_math_environment_group": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_environment_name"
+            },
+            "named": true,
+            "value": "text"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_math_environment_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "math"
+                },
+                {
+                  "type": "STRING",
+                  "value": "displaymath"
+                },
+                {
+                  "type": "STRING",
+                  "value": "displaymath*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "equation"
+                },
+                {
+                  "type": "STRING",
+                  "value": "equation*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "multline"
+                },
+                {
+                  "type": "STRING",
+                  "value": "multline*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "eqnarray"
+                },
+                {
+                  "type": "STRING",
+                  "value": "eqnarray*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "align"
+                },
+                {
+                  "type": "STRING",
+                  "value": "align*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "array"
+                },
+                {
+                  "type": "STRING",
+                  "value": "array*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "split"
+                },
+                {
+                  "type": "STRING",
+                  "value": "split*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "alignat"
+                },
+                {
+                  "type": "STRING",
+                  "value": "alignat*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "gather"
+                },
+                {
+                  "type": "STRING",
+                  "value": "gather*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "flalign"
+                },
+                {
+                  "type": "STRING",
+                  "value": "flalign*"
+                }
+              ]
+            },
+            "named": true,
+            "value": "word"
+          }
+        }
+      ]
+    },
+    "_command": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "title_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "author_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "package_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "latex_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "biblatex_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bibstyle_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bibtex_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "graphics_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "svg_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "inkscape_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "verbatim_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "caption"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "citation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label_reference_range"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "new_command_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "old_command_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "let_command_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "paired_delimiter_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "environment_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "glossary_entry_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "glossary_entry_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "acronym_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "acronym_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "theorem_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "color_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "color_set_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "color_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tikz_library_import"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hyperlink"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generic_command"
+        }
+      ]
+    },
+    "generic_command": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "SYMBOL",
+              "name": "command_name"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "FIELD",
+              "name": "arg",
+              "content": {
+                "type": "SYMBOL",
+                "name": "curly_group"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "command_name": {
+      "type": "PATTERN",
+      "value": "\\\\([^\\r\\n]|[@a-zA-Z]+\\*?)?"
+    },
+    "title_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\title"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "text",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "author_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\author"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "authors",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_author_list"
+          }
+        }
+      ]
+    },
+    "package_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\usepackage"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RequirePackage"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "paths",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path_list"
+          }
+        }
+      ]
+    },
+    "class_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\documentclass"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "latex_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\include"
+              },
+              {
+                "type": "STRING",
+                "value": "\\subfileinclude"
+              },
+              {
+                "type": "STRING",
+                "value": "\\input"
+              },
+              {
+                "type": "STRING",
+                "value": "\\subfile"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "biblatex_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\addbibresource"
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "glob",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_glob_pattern"
+          }
+        }
+      ]
+    },
+    "bibstyle_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\bibliographystyle"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "bibtex_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\bibliography"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "paths",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path_list"
+          }
+        }
+      ]
+    },
+    "graphics_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\includegraphics"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "svg_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\includesvg"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "inkscape_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\includeinkscape"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "verbatim_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\verbatiminput"
+              },
+              {
+                "type": "STRING",
+                "value": "\\VerbatimInput"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "import_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\import"
+              },
+              {
+                "type": "STRING",
+                "value": "\\subimport"
+              },
+              {
+                "type": "STRING",
+                "value": "\\inputfrom"
+              },
+              {
+                "type": "STRING",
+                "value": "\\subimportfrom"
+              },
+              {
+                "type": "STRING",
+                "value": "\\includefrom"
+              },
+              {
+                "type": "STRING",
+                "value": "\\subincludefrom"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "directory",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "file",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path"
+          }
+        }
+      ]
+    },
+    "caption": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\caption"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "short",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "long",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "citation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\cite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\cite*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Cite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\nocite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citet"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citep"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citet*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citep*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeA"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeR"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeS"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeyearR"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeauthor"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeauthor*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Citeauthor"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Citeauthor*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citetitle"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citetitle*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeyear"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeyear*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citedate"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citedate*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeurl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\fullcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citeyearpar"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citealt"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citealp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\citetext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\parencite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\parencite*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Parencite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\footcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\footfullcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\footcitetext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\textcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Textcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\smartcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Smartcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\supercite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\autocite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Autocite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\autocite*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Autocite*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\volcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Volcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\pvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Pvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\fvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ftvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\svolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Svolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\tvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Tvolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\avolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Avolcite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\notecite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Notecite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\pnotecite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Pnotecite"
+              },
+              {
+                "type": "STRING",
+                "value": "\\fnotecite"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "prenote",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "brack_group"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "postnote",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "brack_group"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "keys",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text_list"
+          }
+        }
+      ]
+    },
+    "label_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\label"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "label_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\ref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\eqref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\vref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Vref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\autoref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\pageref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\cref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Cref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\cref*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Cref*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\namecref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\nameCref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\lcnamecref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\namecrefs"
+              },
+              {
+                "type": "STRING",
+                "value": "\\nameCrefs"
+              },
+              {
+                "type": "STRING",
+                "value": "\\lcnamecrefs"
+              },
+              {
+                "type": "STRING",
+                "value": "\\labelcref"
+              },
+              {
+                "type": "STRING",
+                "value": "\\labelcpageref"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "names",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text_list"
+          }
+        }
+      ]
+    },
+    "label_reference_range": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\crefrange"
+              },
+              {
+                "type": "STRING",
+                "value": "\\crefrange*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Crefrange"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Crefrange*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "from",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "to",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "label_number": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\newlabel"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "number",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "new_command_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\newcommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\newcommand*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\renewcommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\renewcommand*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareRobustCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareRobustCommand*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareMathOperator"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareMathOperator*"
+              },
+              {
+                "type": "STRING",
+                "value": "\\NewDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ProvideDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\NewExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ProvideExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareExpandableDocumentCommand"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "declaration",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_command_name"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "argc",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "brack_group_argc"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "default",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "brack_group"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "implementation",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "old_command_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\def"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "declaration",
+          "content": {
+            "type": "SYMBOL",
+            "name": "command_name"
+          }
+        }
+      ]
+    },
+    "let_command_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\let"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "declaration",
+          "content": {
+            "type": "SYMBOL",
+            "name": "command_name"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "implementation",
+          "content": {
+            "type": "SYMBOL",
+            "name": "command_name"
+          }
+        }
+      ]
+    },
+    "_math_delimiter_part": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "word"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "command_name"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        }
+      ]
+    },
+    "math_delimiter": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left_command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\left"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\bigl"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\Bigl"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\biggl"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\Biggl"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "left_delimiter",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_delimiter_part"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_root_content"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right_command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\right"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\bigr"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\Bigr"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\biggr"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\Biggr"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right_delimiter",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_math_delimiter_part"
+            }
+          }
+        ]
+      }
+    },
+    "paired_delimiter_definition": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\DeclarePairedDelimiter"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\DeclarePairedDelimiterX"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "declaration",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_command_name"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "argc",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "brack_group_argc"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "curly_group_impl"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "command_name"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "curly_group_impl"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "command_name"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "body",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "curly_group"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "environment_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\newenvironment"
+              },
+              {
+                "type": "STRING",
+                "value": "\\renewenvironment"
+              },
+              {
+                "type": "STRING",
+                "value": "\\NewDocumentEnvironment"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewDocumentEnvironment"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ProvideDocumentEnvironment"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareDocumentEnvironment"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argc",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_argc"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_impl"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_impl"
+          }
+        }
+      ]
+    },
+    "glossary_entry_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\newglossaryentry"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_key_value"
+          }
+        }
+      ]
+    },
+    "glossary_entry_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\gls"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Gls"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLS"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glspl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glspl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsdisp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glslink"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glstext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glstext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLStext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsfirst"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsfirst"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSfirst"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsfirstplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsfirstplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSfirstplural"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsname"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsname"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSname"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glssymbol"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glssymbol"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsdesc"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsdesc"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSdesc"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuseri"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuseri"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuseri"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuserii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuserii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuserii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuseriii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuseriii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuseriii"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuseriv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuseriv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuseriv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuserv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuserv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuserv"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsuservi"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsuservi"
+              },
+              {
+                "type": "STRING",
+                "value": "\\GLSuservi"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "acronym_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\newacronym"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "short",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "long",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "acronym_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\acrshort"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrshort"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRshort"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acrshortpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrshortpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRshortpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acrlong"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrlong"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRlong"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acrlongpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrlongpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRlongpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acrfull"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrfull"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRfull"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acrfullpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acrfullpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ACRfullpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acs"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acs"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acsp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acsp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\aclp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Aclp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acf"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acf"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acfp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Acfp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ac"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Ac"
+              },
+              {
+                "type": "STRING",
+                "value": "\\acp"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsentrylong"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsentrylong"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsentrylongpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsentrylongpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsentryshort"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsentryshort"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsentryshortpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsentryshortpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\glsentryfullpl"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Glsentryfullpl"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_key_value"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "theorem_definition": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\newtheorem"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\newtheorem*"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\declaretheorem"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\declaretheorem*"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "options",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "brack_group_key_value"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_text_list"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "title",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "curly_group"
+                        }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "counter",
+                        "content": {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "brack_group_text"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "counter",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "brack_group_text"
+                        }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "title",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "curly_group"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "color_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\definecolor"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "brack_group_text"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "model",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "spec",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "color_set_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\definecolorset"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "ty",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_text"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "model",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text_list"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "head",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "tail",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "spec",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "color_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\color"
+              },
+              {
+                "type": "STRING",
+                "value": "\\colorbox"
+              },
+              {
+                "type": "STRING",
+                "value": "\\textcolor"
+              },
+              {
+                "type": "STRING",
+                "value": "\\pagecolor"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        }
+      ]
+    },
+    "tikz_library_import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\usepgflibrary"
+              },
+              {
+                "type": "STRING",
+                "value": "\\usetikzlibrary"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "paths",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_path_list"
+          }
+        }
+      ]
+    },
+    "text_mode": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\text"
+              },
+              {
+                "type": "STRING",
+                "value": "\\intertext"
+              },
+              {
+                "type": "STRING",
+                "value": "\\shortintertext"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "content",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "hyperlink": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\url"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\href"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "uri",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_uri"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "label",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "curly_group"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "extras": [
+    {
+      "type": "SYMBOL",
+      "name": "_whitespace"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "line_comment"
+    }
+  ],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_fi"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_verbatim"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_listing"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_minted"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_pycode"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_sagesilent"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_trivia_raw_env_sageblock"
+    }
+  ],
+  "inline": [],
+  "supertypes": []
+}

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,0 +1,9005 @@
+[
+  {
+    "type": "acronym_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\newacronym",
+            "named": false
+          }
+        ]
+      },
+      "long": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "short": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "acronym_reference",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\ACRfull",
+            "named": false
+          },
+          {
+            "type": "\\ACRfullpl",
+            "named": false
+          },
+          {
+            "type": "\\ACRlong",
+            "named": false
+          },
+          {
+            "type": "\\ACRlongpl",
+            "named": false
+          },
+          {
+            "type": "\\ACRshort",
+            "named": false
+          },
+          {
+            "type": "\\ACRshortpl",
+            "named": false
+          },
+          {
+            "type": "\\Ac",
+            "named": false
+          },
+          {
+            "type": "\\Acf",
+            "named": false
+          },
+          {
+            "type": "\\Acfp",
+            "named": false
+          },
+          {
+            "type": "\\Acl",
+            "named": false
+          },
+          {
+            "type": "\\Aclp",
+            "named": false
+          },
+          {
+            "type": "\\Acrfull",
+            "named": false
+          },
+          {
+            "type": "\\Acrfullpl",
+            "named": false
+          },
+          {
+            "type": "\\Acrlong",
+            "named": false
+          },
+          {
+            "type": "\\Acrlongpl",
+            "named": false
+          },
+          {
+            "type": "\\Acrshort",
+            "named": false
+          },
+          {
+            "type": "\\Acrshortpl",
+            "named": false
+          },
+          {
+            "type": "\\Acs",
+            "named": false
+          },
+          {
+            "type": "\\Acsp",
+            "named": false
+          },
+          {
+            "type": "\\Glsentryfullpl",
+            "named": false
+          },
+          {
+            "type": "\\Glsentrylong",
+            "named": false
+          },
+          {
+            "type": "\\Glsentrylongpl",
+            "named": false
+          },
+          {
+            "type": "\\Glsentryshort",
+            "named": false
+          },
+          {
+            "type": "\\Glsentryshortpl",
+            "named": false
+          },
+          {
+            "type": "\\ac",
+            "named": false
+          },
+          {
+            "type": "\\acf",
+            "named": false
+          },
+          {
+            "type": "\\acfp",
+            "named": false
+          },
+          {
+            "type": "\\acl",
+            "named": false
+          },
+          {
+            "type": "\\aclp",
+            "named": false
+          },
+          {
+            "type": "\\acp",
+            "named": false
+          },
+          {
+            "type": "\\acrfull",
+            "named": false
+          },
+          {
+            "type": "\\acrfullpl",
+            "named": false
+          },
+          {
+            "type": "\\acrlong",
+            "named": false
+          },
+          {
+            "type": "\\acrlongpl",
+            "named": false
+          },
+          {
+            "type": "\\acrshort",
+            "named": false
+          },
+          {
+            "type": "\\acrshortpl",
+            "named": false
+          },
+          {
+            "type": "\\acs",
+            "named": false
+          },
+          {
+            "type": "\\acsp",
+            "named": false
+          },
+          {
+            "type": "\\glsentryfullpl",
+            "named": false
+          },
+          {
+            "type": "\\glsentrylong",
+            "named": false
+          },
+          {
+            "type": "\\glsentrylongpl",
+            "named": false
+          },
+          {
+            "type": "\\glsentryshort",
+            "named": false
+          },
+          {
+            "type": "\\glsentryshortpl",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "author",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "author_declaration",
+    "named": true,
+    "fields": {
+      "authors": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_author_list",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\author",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "begin",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\begin",
+            "named": false
+          }
+        ]
+      },
+      "language": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          },
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "biblatex_include",
+    "named": true,
+    "fields": {
+      "glob": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_glob_pattern",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bibstyle_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\bibliographystyle",
+            "named": false
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bibtex_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\bibliography",
+            "named": false
+          }
+        ]
+      },
+      "paths": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "block_comment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\iffalse",
+            "named": false
+          }
+        ]
+      },
+      "comment": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "comment",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "\\fi",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "brack_group",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "brack_group",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "brack_group_argc",
+    "named": true,
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argc",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "brack_group_key_value",
+    "named": true,
+    "fields": {
+      "pair": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "key_value_pair",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "brack_group_text",
+    "named": true,
+    "fields": {
+      "text": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "caption",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\caption",
+            "named": false
+          }
+        ]
+      },
+      "long": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "short": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "chapter",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\addchap",
+            "named": false
+          },
+          {
+            "type": "\\addchap*",
+            "named": false
+          },
+          {
+            "type": "\\chapter",
+            "named": false
+          },
+          {
+            "type": "\\chapter*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "citation",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Autocite",
+            "named": false
+          },
+          {
+            "type": "\\Autocite*",
+            "named": false
+          },
+          {
+            "type": "\\Avolcite",
+            "named": false
+          },
+          {
+            "type": "\\Cite",
+            "named": false
+          },
+          {
+            "type": "\\Citeauthor",
+            "named": false
+          },
+          {
+            "type": "\\Citeauthor*",
+            "named": false
+          },
+          {
+            "type": "\\Notecite",
+            "named": false
+          },
+          {
+            "type": "\\Parencite",
+            "named": false
+          },
+          {
+            "type": "\\Pnotecite",
+            "named": false
+          },
+          {
+            "type": "\\Pvolcite",
+            "named": false
+          },
+          {
+            "type": "\\Smartcite",
+            "named": false
+          },
+          {
+            "type": "\\Svolcite",
+            "named": false
+          },
+          {
+            "type": "\\Textcite",
+            "named": false
+          },
+          {
+            "type": "\\Tvolcite",
+            "named": false
+          },
+          {
+            "type": "\\Volcite",
+            "named": false
+          },
+          {
+            "type": "\\autocite",
+            "named": false
+          },
+          {
+            "type": "\\autocite*",
+            "named": false
+          },
+          {
+            "type": "\\avolcite",
+            "named": false
+          },
+          {
+            "type": "\\cite",
+            "named": false
+          },
+          {
+            "type": "\\cite*",
+            "named": false
+          },
+          {
+            "type": "\\citeA",
+            "named": false
+          },
+          {
+            "type": "\\citeR",
+            "named": false
+          },
+          {
+            "type": "\\citeS",
+            "named": false
+          },
+          {
+            "type": "\\citealp",
+            "named": false
+          },
+          {
+            "type": "\\citealt",
+            "named": false
+          },
+          {
+            "type": "\\citeauthor",
+            "named": false
+          },
+          {
+            "type": "\\citeauthor*",
+            "named": false
+          },
+          {
+            "type": "\\citedate",
+            "named": false
+          },
+          {
+            "type": "\\citedate*",
+            "named": false
+          },
+          {
+            "type": "\\citep",
+            "named": false
+          },
+          {
+            "type": "\\citep*",
+            "named": false
+          },
+          {
+            "type": "\\citet",
+            "named": false
+          },
+          {
+            "type": "\\citet*",
+            "named": false
+          },
+          {
+            "type": "\\citetext",
+            "named": false
+          },
+          {
+            "type": "\\citetitle",
+            "named": false
+          },
+          {
+            "type": "\\citetitle*",
+            "named": false
+          },
+          {
+            "type": "\\citeurl",
+            "named": false
+          },
+          {
+            "type": "\\citeyear",
+            "named": false
+          },
+          {
+            "type": "\\citeyear*",
+            "named": false
+          },
+          {
+            "type": "\\citeyearR",
+            "named": false
+          },
+          {
+            "type": "\\citeyearpar",
+            "named": false
+          },
+          {
+            "type": "\\fnotecite",
+            "named": false
+          },
+          {
+            "type": "\\footcite",
+            "named": false
+          },
+          {
+            "type": "\\footcitetext",
+            "named": false
+          },
+          {
+            "type": "\\footfullcite",
+            "named": false
+          },
+          {
+            "type": "\\ftvolcite",
+            "named": false
+          },
+          {
+            "type": "\\fullcite",
+            "named": false
+          },
+          {
+            "type": "\\fvolcite",
+            "named": false
+          },
+          {
+            "type": "\\nocite",
+            "named": false
+          },
+          {
+            "type": "\\notecite",
+            "named": false
+          },
+          {
+            "type": "\\parencite",
+            "named": false
+          },
+          {
+            "type": "\\parencite*",
+            "named": false
+          },
+          {
+            "type": "\\pnotecite",
+            "named": false
+          },
+          {
+            "type": "\\pvolcite",
+            "named": false
+          },
+          {
+            "type": "\\smartcite",
+            "named": false
+          },
+          {
+            "type": "\\supercite",
+            "named": false
+          },
+          {
+            "type": "\\svolcite",
+            "named": false
+          },
+          {
+            "type": "\\textcite",
+            "named": false
+          },
+          {
+            "type": "\\tvolcite",
+            "named": false
+          },
+          {
+            "type": "\\volcite",
+            "named": false
+          }
+        ]
+      },
+      "keys": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text_list",
+            "named": true
+          }
+        ]
+      },
+      "postnote": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      },
+      "prenote": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "class_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\documentclass",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "color_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\definecolor",
+            "named": false
+          }
+        ]
+      },
+      "model": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "spec": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "brack_group_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "color_reference",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\color",
+            "named": false
+          },
+          {
+            "type": "\\colorbox",
+            "named": false
+          },
+          {
+            "type": "\\pagecolor",
+            "named": false
+          },
+          {
+            "type": "\\textcolor",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "color_set_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\definecolorset",
+            "named": false
+          }
+        ]
+      },
+      "head": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "model": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text_list",
+            "named": true
+          }
+        ]
+      },
+      "spec": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "tail": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "ty": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "comment_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "comment": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "comment",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "curly_group_author_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "author",
+          "named": true
+        },
+        {
+          "type": "command_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "curly_group_command_name",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_glob_pattern",
+    "named": true,
+    "fields": {
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "glob_pattern",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_impl",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "curly_group_key_value",
+    "named": true,
+    "fields": {
+      "pair": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "key_value_pair",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_path",
+    "named": true,
+    "fields": {
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_path_list",
+    "named": true,
+    "fields": {
+      "path": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_text",
+    "named": true,
+    "fields": {
+      "text": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_text_list",
+    "named": true,
+    "fields": {
+      "text": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_uri",
+    "named": true,
+    "fields": {
+      "uri": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "uri",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "displayed_equation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "end",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\end",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "enum_item",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\item",
+            "named": false
+          },
+          {
+            "type": "\\item*",
+            "named": false
+          }
+        ]
+      },
+      "label": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_text",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "environment_definition",
+    "named": true,
+    "fields": {
+      "argc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_argc",
+            "named": true
+          }
+        ]
+      },
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_impl",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\DeclareDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\NewDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\ProvideDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\RenewDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\newenvironment",
+            "named": false
+          },
+          {
+            "type": "\\renewenvironment",
+            "named": false
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_impl",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "generic_command",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "generic_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "glob_pattern",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "glossary_entry_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\newglossaryentry",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_key_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "glossary_entry_reference",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\GLS",
+            "named": false
+          },
+          {
+            "type": "\\GLSdesc",
+            "named": false
+          },
+          {
+            "type": "\\GLSfirst",
+            "named": false
+          },
+          {
+            "type": "\\GLSfirstplural",
+            "named": false
+          },
+          {
+            "type": "\\GLSname",
+            "named": false
+          },
+          {
+            "type": "\\GLSpl",
+            "named": false
+          },
+          {
+            "type": "\\GLSplural",
+            "named": false
+          },
+          {
+            "type": "\\GLStext",
+            "named": false
+          },
+          {
+            "type": "\\GLSuseri",
+            "named": false
+          },
+          {
+            "type": "\\GLSuserii",
+            "named": false
+          },
+          {
+            "type": "\\GLSuseriii",
+            "named": false
+          },
+          {
+            "type": "\\GLSuseriv",
+            "named": false
+          },
+          {
+            "type": "\\GLSuserv",
+            "named": false
+          },
+          {
+            "type": "\\GLSuservi",
+            "named": false
+          },
+          {
+            "type": "\\Gls",
+            "named": false
+          },
+          {
+            "type": "\\Glsdesc",
+            "named": false
+          },
+          {
+            "type": "\\Glsfirst",
+            "named": false
+          },
+          {
+            "type": "\\Glsfirstplural",
+            "named": false
+          },
+          {
+            "type": "\\Glsname",
+            "named": false
+          },
+          {
+            "type": "\\Glspl",
+            "named": false
+          },
+          {
+            "type": "\\Glsplural",
+            "named": false
+          },
+          {
+            "type": "\\Glssymbol",
+            "named": false
+          },
+          {
+            "type": "\\Glstext",
+            "named": false
+          },
+          {
+            "type": "\\Glsuseri",
+            "named": false
+          },
+          {
+            "type": "\\Glsuserii",
+            "named": false
+          },
+          {
+            "type": "\\Glsuseriii",
+            "named": false
+          },
+          {
+            "type": "\\Glsuseriv",
+            "named": false
+          },
+          {
+            "type": "\\Glsuserv",
+            "named": false
+          },
+          {
+            "type": "\\Glsuservi",
+            "named": false
+          },
+          {
+            "type": "\\gls",
+            "named": false
+          },
+          {
+            "type": "\\glsdesc",
+            "named": false
+          },
+          {
+            "type": "\\glsdisp",
+            "named": false
+          },
+          {
+            "type": "\\glsfirst",
+            "named": false
+          },
+          {
+            "type": "\\glsfirstplural",
+            "named": false
+          },
+          {
+            "type": "\\glslink",
+            "named": false
+          },
+          {
+            "type": "\\glsname",
+            "named": false
+          },
+          {
+            "type": "\\glspl",
+            "named": false
+          },
+          {
+            "type": "\\glsplural",
+            "named": false
+          },
+          {
+            "type": "\\glssymbol",
+            "named": false
+          },
+          {
+            "type": "\\glstext",
+            "named": false
+          },
+          {
+            "type": "\\glsuseri",
+            "named": false
+          },
+          {
+            "type": "\\glsuserii",
+            "named": false
+          },
+          {
+            "type": "\\glsuseriii",
+            "named": false
+          },
+          {
+            "type": "\\glsuseriv",
+            "named": false
+          },
+          {
+            "type": "\\glsuserv",
+            "named": false
+          },
+          {
+            "type": "\\glsuservi",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "graphics_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\includegraphics",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "hyperlink",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\href",
+            "named": false
+          },
+          {
+            "type": "\\url",
+            "named": false
+          }
+        ]
+      },
+      "label": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "uri": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_uri",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "import_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\import",
+            "named": false
+          },
+          {
+            "type": "\\includefrom",
+            "named": false
+          },
+          {
+            "type": "\\inputfrom",
+            "named": false
+          },
+          {
+            "type": "\\subimport",
+            "named": false
+          },
+          {
+            "type": "\\subimportfrom",
+            "named": false
+          },
+          {
+            "type": "\\subincludefrom",
+            "named": false
+          }
+        ]
+      },
+      "directory": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      },
+      "file": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "inkscape_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\includeinkscape",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "inline_formula",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_value_pair",
+    "named": true,
+    "fields": {
+      "key": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "text",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "label_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\label",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "label_number",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\newlabel",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "number": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "label_reference",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Cref",
+            "named": false
+          },
+          {
+            "type": "\\Cref*",
+            "named": false
+          },
+          {
+            "type": "\\Vref",
+            "named": false
+          },
+          {
+            "type": "\\autoref",
+            "named": false
+          },
+          {
+            "type": "\\cref",
+            "named": false
+          },
+          {
+            "type": "\\cref*",
+            "named": false
+          },
+          {
+            "type": "\\eqref",
+            "named": false
+          },
+          {
+            "type": "\\labelcpageref",
+            "named": false
+          },
+          {
+            "type": "\\labelcref",
+            "named": false
+          },
+          {
+            "type": "\\lcnamecref",
+            "named": false
+          },
+          {
+            "type": "\\lcnamecrefs",
+            "named": false
+          },
+          {
+            "type": "\\nameCref",
+            "named": false
+          },
+          {
+            "type": "\\nameCrefs",
+            "named": false
+          },
+          {
+            "type": "\\namecref",
+            "named": false
+          },
+          {
+            "type": "\\namecrefs",
+            "named": false
+          },
+          {
+            "type": "\\pageref",
+            "named": false
+          },
+          {
+            "type": "\\ref",
+            "named": false
+          },
+          {
+            "type": "\\vref",
+            "named": false
+          }
+        ]
+      },
+      "names": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "label_reference_range",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Crefrange",
+            "named": false
+          },
+          {
+            "type": "\\Crefrange*",
+            "named": false
+          },
+          {
+            "type": "\\crefrange",
+            "named": false
+          },
+          {
+            "type": "\\crefrange*",
+            "named": false
+          }
+        ]
+      },
+      "from": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "to": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "latex_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\include",
+            "named": false
+          },
+          {
+            "type": "\\input",
+            "named": false
+          },
+          {
+            "type": "\\subfile",
+            "named": false
+          },
+          {
+            "type": "\\subfileinclude",
+            "named": false
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "let_command_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\let",
+            "named": false
+          }
+        ]
+      },
+      "declaration": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          }
+        ]
+      },
+      "implementation": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "listing_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "code": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "source_code",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "math_delimiter",
+    "named": true,
+    "fields": {
+      "left_command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Biggl",
+            "named": false
+          },
+          {
+            "type": "\\Bigl",
+            "named": false
+          },
+          {
+            "type": "\\biggl",
+            "named": false
+          },
+          {
+            "type": "\\bigl",
+            "named": false
+          },
+          {
+            "type": "\\left",
+            "named": false
+          }
+        ]
+      },
+      "left_delimiter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "[",
+            "named": false
+          },
+          {
+            "type": "]",
+            "named": false
+          },
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          },
+          {
+            "type": "|",
+            "named": false
+          }
+        ]
+      },
+      "right_command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Biggr",
+            "named": false
+          },
+          {
+            "type": "\\Bigr",
+            "named": false
+          },
+          {
+            "type": "\\biggr",
+            "named": false
+          },
+          {
+            "type": "\\bigr",
+            "named": false
+          },
+          {
+            "type": "\\right",
+            "named": false
+          }
+        ]
+      },
+      "right_delimiter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "[",
+            "named": false
+          },
+          {
+            "type": "]",
+            "named": false
+          },
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          },
+          {
+            "type": "|",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "minted_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "code": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "source_code",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "new_command_definition",
+    "named": true,
+    "fields": {
+      "argc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_argc",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\DeclareDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\DeclareExpandableDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\DeclareMathOperator",
+            "named": false
+          },
+          {
+            "type": "\\DeclareMathOperator*",
+            "named": false
+          },
+          {
+            "type": "\\DeclareRobustCommand",
+            "named": false
+          },
+          {
+            "type": "\\DeclareRobustCommand*",
+            "named": false
+          },
+          {
+            "type": "\\NewDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\NewExpandableDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\ProvideDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\ProvideExpandableDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\RenewDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\RenewExpandableDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\newcommand",
+            "named": false
+          },
+          {
+            "type": "\\newcommand*",
+            "named": false
+          },
+          {
+            "type": "\\renewcommand",
+            "named": false
+          },
+          {
+            "type": "\\renewcommand*",
+            "named": false
+          }
+        ]
+      },
+      "declaration": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_command_name",
+            "named": true
+          }
+        ]
+      },
+      "default": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      },
+      "implementation": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "old_command_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\def",
+            "named": false
+          }
+        ]
+      },
+      "declaration": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "operator",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "package_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\RequirePackage",
+            "named": false
+          },
+          {
+            "type": "\\usepackage",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "paths": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "paired_delimiter_definition",
+    "named": true,
+    "fields": {
+      "argc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_argc",
+            "named": true
+          }
+        ]
+      },
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\DeclarePairedDelimiter",
+            "named": false
+          },
+          {
+            "type": "\\DeclarePairedDelimiterX",
+            "named": false
+          }
+        ]
+      },
+      "declaration": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_command_name",
+            "named": true
+          }
+        ]
+      },
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "curly_group_impl",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "curly_group_impl",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "paragraph",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\paragraph",
+            "named": false
+          },
+          {
+            "type": "\\paragraph*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "part",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\addpart",
+            "named": false
+          },
+          {
+            "type": "\\addpart*",
+            "named": false
+          },
+          {
+            "type": "\\part",
+            "named": false
+          },
+          {
+            "type": "\\part*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pycode_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "code": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "source_code",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "sageblock_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "code": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "source_code",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "sagesilent_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "code": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "source_code",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "section",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\addsec",
+            "named": false
+          },
+          {
+            "type": "\\addsec*",
+            "named": false
+          },
+          {
+            "type": "\\section",
+            "named": false
+          },
+          {
+            "type": "\\section*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "chapter",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "part",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "section",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsection",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subparagraph",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\subparagraph",
+            "named": false
+          },
+          {
+            "type": "\\subparagraph*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subscript",
+    "named": true,
+    "fields": {
+      "subscript": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "curly_group",
+            "named": true
+          },
+          {
+            "type": "letter",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "subsection",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\subsection",
+            "named": false
+          },
+          {
+            "type": "\\subsection*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "subsubsection",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subsubsection",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\subsubsection",
+            "named": false
+          },
+          {
+            "type": "\\subsubsection*",
+            "named": false
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "toc": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "enum_item",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "generic_environment",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "listing_environment",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "math_environment",
+          "named": true
+        },
+        {
+          "type": "minted_environment",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "pycode_environment",
+          "named": true
+        },
+        {
+          "type": "sageblock_environment",
+          "named": true
+        },
+        {
+          "type": "sagesilent_environment",
+          "named": true
+        },
+        {
+          "type": "subparagraph",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_environment",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "superscript",
+    "named": true,
+    "fields": {
+      "superscript": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "command_name",
+            "named": true
+          },
+          {
+            "type": "curly_group",
+            "named": true
+          },
+          {
+            "type": "letter",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "svg_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\includesvg",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "text",
+    "named": true,
+    "fields": {
+      "word": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "acronym_definition",
+            "named": true
+          },
+          {
+            "type": "acronym_reference",
+            "named": true
+          },
+          {
+            "type": "author_declaration",
+            "named": true
+          },
+          {
+            "type": "biblatex_include",
+            "named": true
+          },
+          {
+            "type": "bibstyle_include",
+            "named": true
+          },
+          {
+            "type": "bibtex_include",
+            "named": true
+          },
+          {
+            "type": "block_comment",
+            "named": true
+          },
+          {
+            "type": "caption",
+            "named": true
+          },
+          {
+            "type": "citation",
+            "named": true
+          },
+          {
+            "type": "class_include",
+            "named": true
+          },
+          {
+            "type": "color_definition",
+            "named": true
+          },
+          {
+            "type": "color_reference",
+            "named": true
+          },
+          {
+            "type": "color_set_definition",
+            "named": true
+          },
+          {
+            "type": "environment_definition",
+            "named": true
+          },
+          {
+            "type": "generic_command",
+            "named": true
+          },
+          {
+            "type": "glossary_entry_definition",
+            "named": true
+          },
+          {
+            "type": "glossary_entry_reference",
+            "named": true
+          },
+          {
+            "type": "graphics_include",
+            "named": true
+          },
+          {
+            "type": "hyperlink",
+            "named": true
+          },
+          {
+            "type": "import_include",
+            "named": true
+          },
+          {
+            "type": "inkscape_include",
+            "named": true
+          },
+          {
+            "type": "label_definition",
+            "named": true
+          },
+          {
+            "type": "label_number",
+            "named": true
+          },
+          {
+            "type": "label_reference",
+            "named": true
+          },
+          {
+            "type": "label_reference_range",
+            "named": true
+          },
+          {
+            "type": "latex_include",
+            "named": true
+          },
+          {
+            "type": "let_command_definition",
+            "named": true
+          },
+          {
+            "type": "new_command_definition",
+            "named": true
+          },
+          {
+            "type": "old_command_definition",
+            "named": true
+          },
+          {
+            "type": "operator",
+            "named": true
+          },
+          {
+            "type": "package_include",
+            "named": true
+          },
+          {
+            "type": "paired_delimiter_definition",
+            "named": true
+          },
+          {
+            "type": "placeholder",
+            "named": true
+          },
+          {
+            "type": "subscript",
+            "named": true
+          },
+          {
+            "type": "superscript",
+            "named": true
+          },
+          {
+            "type": "svg_include",
+            "named": true
+          },
+          {
+            "type": "theorem_definition",
+            "named": true
+          },
+          {
+            "type": "tikz_library_import",
+            "named": true
+          },
+          {
+            "type": "title_declaration",
+            "named": true
+          },
+          {
+            "type": "verbatim_include",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "text_mode",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\intertext",
+            "named": false
+          },
+          {
+            "type": "\\shortintertext",
+            "named": false
+          },
+          {
+            "type": "\\text",
+            "named": false
+          }
+        ]
+      },
+      "content": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "theorem_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\declaretheorem",
+            "named": false
+          },
+          {
+            "type": "\\declaretheorem*",
+            "named": false
+          },
+          {
+            "type": "\\newtheorem",
+            "named": false
+          },
+          {
+            "type": "\\newtheorem*",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_text",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_text_list",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_key_value",
+            "named": true
+          }
+        ]
+      },
+      "title": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "tikz_library_import",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\usepgflibrary",
+            "named": false
+          },
+          {
+            "type": "\\usetikzlibrary",
+            "named": false
+          }
+        ]
+      },
+      "paths": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "title_declaration",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\title",
+            "named": false
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "brack_group",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "verbatim_environment",
+    "named": true,
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "begin",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "end",
+            "named": true
+          }
+        ]
+      },
+      "verbatim": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "comment",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "verbatim_include",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\VerbatimInput",
+            "named": false
+          },
+          {
+            "type": "\\verbatiminput",
+            "named": false
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_path",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "!",
+    "named": false
+  },
+  {
+    "type": "$",
+    "named": false
+  },
+  {
+    "type": "$$",
+    "named": false
+  },
+  {
+    "type": "'",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "\\(",
+    "named": false
+  },
+  {
+    "type": "\\)",
+    "named": false
+  },
+  {
+    "type": "\\ACRfull",
+    "named": false
+  },
+  {
+    "type": "\\ACRfullpl",
+    "named": false
+  },
+  {
+    "type": "\\ACRlong",
+    "named": false
+  },
+  {
+    "type": "\\ACRlongpl",
+    "named": false
+  },
+  {
+    "type": "\\ACRshort",
+    "named": false
+  },
+  {
+    "type": "\\ACRshortpl",
+    "named": false
+  },
+  {
+    "type": "\\Ac",
+    "named": false
+  },
+  {
+    "type": "\\Acf",
+    "named": false
+  },
+  {
+    "type": "\\Acfp",
+    "named": false
+  },
+  {
+    "type": "\\Acl",
+    "named": false
+  },
+  {
+    "type": "\\Aclp",
+    "named": false
+  },
+  {
+    "type": "\\Acrfull",
+    "named": false
+  },
+  {
+    "type": "\\Acrfullpl",
+    "named": false
+  },
+  {
+    "type": "\\Acrlong",
+    "named": false
+  },
+  {
+    "type": "\\Acrlongpl",
+    "named": false
+  },
+  {
+    "type": "\\Acrshort",
+    "named": false
+  },
+  {
+    "type": "\\Acrshortpl",
+    "named": false
+  },
+  {
+    "type": "\\Acs",
+    "named": false
+  },
+  {
+    "type": "\\Acsp",
+    "named": false
+  },
+  {
+    "type": "\\Autocite",
+    "named": false
+  },
+  {
+    "type": "\\Autocite*",
+    "named": false
+  },
+  {
+    "type": "\\Avolcite",
+    "named": false
+  },
+  {
+    "type": "\\Biggl",
+    "named": false
+  },
+  {
+    "type": "\\Biggr",
+    "named": false
+  },
+  {
+    "type": "\\Bigl",
+    "named": false
+  },
+  {
+    "type": "\\Bigr",
+    "named": false
+  },
+  {
+    "type": "\\Cite",
+    "named": false
+  },
+  {
+    "type": "\\Citeauthor",
+    "named": false
+  },
+  {
+    "type": "\\Citeauthor*",
+    "named": false
+  },
+  {
+    "type": "\\Cref",
+    "named": false
+  },
+  {
+    "type": "\\Cref*",
+    "named": false
+  },
+  {
+    "type": "\\Crefrange",
+    "named": false
+  },
+  {
+    "type": "\\Crefrange*",
+    "named": false
+  },
+  {
+    "type": "\\DeclareDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\DeclareDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\DeclareExpandableDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\DeclareMathOperator",
+    "named": false
+  },
+  {
+    "type": "\\DeclareMathOperator*",
+    "named": false
+  },
+  {
+    "type": "\\DeclarePairedDelimiter",
+    "named": false
+  },
+  {
+    "type": "\\DeclarePairedDelimiterX",
+    "named": false
+  },
+  {
+    "type": "\\DeclareRobustCommand",
+    "named": false
+  },
+  {
+    "type": "\\DeclareRobustCommand*",
+    "named": false
+  },
+  {
+    "type": "\\GLS",
+    "named": false
+  },
+  {
+    "type": "\\GLSdesc",
+    "named": false
+  },
+  {
+    "type": "\\GLSfirst",
+    "named": false
+  },
+  {
+    "type": "\\GLSfirstplural",
+    "named": false
+  },
+  {
+    "type": "\\GLSname",
+    "named": false
+  },
+  {
+    "type": "\\GLSpl",
+    "named": false
+  },
+  {
+    "type": "\\GLSplural",
+    "named": false
+  },
+  {
+    "type": "\\GLStext",
+    "named": false
+  },
+  {
+    "type": "\\GLSuseri",
+    "named": false
+  },
+  {
+    "type": "\\GLSuserii",
+    "named": false
+  },
+  {
+    "type": "\\GLSuseriii",
+    "named": false
+  },
+  {
+    "type": "\\GLSuseriv",
+    "named": false
+  },
+  {
+    "type": "\\GLSuserv",
+    "named": false
+  },
+  {
+    "type": "\\GLSuservi",
+    "named": false
+  },
+  {
+    "type": "\\Gls",
+    "named": false
+  },
+  {
+    "type": "\\Glsdesc",
+    "named": false
+  },
+  {
+    "type": "\\Glsentryfullpl",
+    "named": false
+  },
+  {
+    "type": "\\Glsentrylong",
+    "named": false
+  },
+  {
+    "type": "\\Glsentrylongpl",
+    "named": false
+  },
+  {
+    "type": "\\Glsentryshort",
+    "named": false
+  },
+  {
+    "type": "\\Glsentryshortpl",
+    "named": false
+  },
+  {
+    "type": "\\Glsfirst",
+    "named": false
+  },
+  {
+    "type": "\\Glsfirstplural",
+    "named": false
+  },
+  {
+    "type": "\\Glsname",
+    "named": false
+  },
+  {
+    "type": "\\Glspl",
+    "named": false
+  },
+  {
+    "type": "\\Glsplural",
+    "named": false
+  },
+  {
+    "type": "\\Glssymbol",
+    "named": false
+  },
+  {
+    "type": "\\Glstext",
+    "named": false
+  },
+  {
+    "type": "\\Glsuseri",
+    "named": false
+  },
+  {
+    "type": "\\Glsuserii",
+    "named": false
+  },
+  {
+    "type": "\\Glsuseriii",
+    "named": false
+  },
+  {
+    "type": "\\Glsuseriv",
+    "named": false
+  },
+  {
+    "type": "\\Glsuserv",
+    "named": false
+  },
+  {
+    "type": "\\Glsuservi",
+    "named": false
+  },
+  {
+    "type": "\\NewDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\NewDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\NewExpandableDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\Notecite",
+    "named": false
+  },
+  {
+    "type": "\\Parencite",
+    "named": false
+  },
+  {
+    "type": "\\Pnotecite",
+    "named": false
+  },
+  {
+    "type": "\\ProvideDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\ProvideDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\ProvideExpandableDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\Pvolcite",
+    "named": false
+  },
+  {
+    "type": "\\RenewDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\RenewDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\RenewExpandableDocumentCommand",
+    "named": false
+  },
+  {
+    "type": "\\RequirePackage",
+    "named": false
+  },
+  {
+    "type": "\\Smartcite",
+    "named": false
+  },
+  {
+    "type": "\\Svolcite",
+    "named": false
+  },
+  {
+    "type": "\\Textcite",
+    "named": false
+  },
+  {
+    "type": "\\Tvolcite",
+    "named": false
+  },
+  {
+    "type": "\\VerbatimInput",
+    "named": false
+  },
+  {
+    "type": "\\Volcite",
+    "named": false
+  },
+  {
+    "type": "\\Vref",
+    "named": false
+  },
+  {
+    "type": "\\[",
+    "named": false
+  },
+  {
+    "type": "\\]",
+    "named": false
+  },
+  {
+    "type": "\\ac",
+    "named": false
+  },
+  {
+    "type": "\\acf",
+    "named": false
+  },
+  {
+    "type": "\\acfp",
+    "named": false
+  },
+  {
+    "type": "\\acl",
+    "named": false
+  },
+  {
+    "type": "\\aclp",
+    "named": false
+  },
+  {
+    "type": "\\acp",
+    "named": false
+  },
+  {
+    "type": "\\acrfull",
+    "named": false
+  },
+  {
+    "type": "\\acrfullpl",
+    "named": false
+  },
+  {
+    "type": "\\acrlong",
+    "named": false
+  },
+  {
+    "type": "\\acrlongpl",
+    "named": false
+  },
+  {
+    "type": "\\acrshort",
+    "named": false
+  },
+  {
+    "type": "\\acrshortpl",
+    "named": false
+  },
+  {
+    "type": "\\acs",
+    "named": false
+  },
+  {
+    "type": "\\acsp",
+    "named": false
+  },
+  {
+    "type": "\\addbibresource",
+    "named": false
+  },
+  {
+    "type": "\\addchap",
+    "named": false
+  },
+  {
+    "type": "\\addchap*",
+    "named": false
+  },
+  {
+    "type": "\\addpart",
+    "named": false
+  },
+  {
+    "type": "\\addpart*",
+    "named": false
+  },
+  {
+    "type": "\\addsec",
+    "named": false
+  },
+  {
+    "type": "\\addsec*",
+    "named": false
+  },
+  {
+    "type": "\\author",
+    "named": false
+  },
+  {
+    "type": "\\autocite",
+    "named": false
+  },
+  {
+    "type": "\\autocite*",
+    "named": false
+  },
+  {
+    "type": "\\autoref",
+    "named": false
+  },
+  {
+    "type": "\\avolcite",
+    "named": false
+  },
+  {
+    "type": "\\begin",
+    "named": false
+  },
+  {
+    "type": "\\bibliography",
+    "named": false
+  },
+  {
+    "type": "\\bibliographystyle",
+    "named": false
+  },
+  {
+    "type": "\\biggl",
+    "named": false
+  },
+  {
+    "type": "\\biggr",
+    "named": false
+  },
+  {
+    "type": "\\bigl",
+    "named": false
+  },
+  {
+    "type": "\\bigr",
+    "named": false
+  },
+  {
+    "type": "\\caption",
+    "named": false
+  },
+  {
+    "type": "\\chapter",
+    "named": false
+  },
+  {
+    "type": "\\chapter*",
+    "named": false
+  },
+  {
+    "type": "\\cite",
+    "named": false
+  },
+  {
+    "type": "\\cite*",
+    "named": false
+  },
+  {
+    "type": "\\citeA",
+    "named": false
+  },
+  {
+    "type": "\\citeR",
+    "named": false
+  },
+  {
+    "type": "\\citeS",
+    "named": false
+  },
+  {
+    "type": "\\citealp",
+    "named": false
+  },
+  {
+    "type": "\\citealt",
+    "named": false
+  },
+  {
+    "type": "\\citeauthor",
+    "named": false
+  },
+  {
+    "type": "\\citeauthor*",
+    "named": false
+  },
+  {
+    "type": "\\citedate",
+    "named": false
+  },
+  {
+    "type": "\\citedate*",
+    "named": false
+  },
+  {
+    "type": "\\citep",
+    "named": false
+  },
+  {
+    "type": "\\citep*",
+    "named": false
+  },
+  {
+    "type": "\\citet",
+    "named": false
+  },
+  {
+    "type": "\\citet*",
+    "named": false
+  },
+  {
+    "type": "\\citetext",
+    "named": false
+  },
+  {
+    "type": "\\citetitle",
+    "named": false
+  },
+  {
+    "type": "\\citetitle*",
+    "named": false
+  },
+  {
+    "type": "\\citeurl",
+    "named": false
+  },
+  {
+    "type": "\\citeyear",
+    "named": false
+  },
+  {
+    "type": "\\citeyear*",
+    "named": false
+  },
+  {
+    "type": "\\citeyearR",
+    "named": false
+  },
+  {
+    "type": "\\citeyearpar",
+    "named": false
+  },
+  {
+    "type": "\\color",
+    "named": false
+  },
+  {
+    "type": "\\colorbox",
+    "named": false
+  },
+  {
+    "type": "\\cref",
+    "named": false
+  },
+  {
+    "type": "\\cref*",
+    "named": false
+  },
+  {
+    "type": "\\crefrange",
+    "named": false
+  },
+  {
+    "type": "\\crefrange*",
+    "named": false
+  },
+  {
+    "type": "\\declaretheorem",
+    "named": false
+  },
+  {
+    "type": "\\declaretheorem*",
+    "named": false
+  },
+  {
+    "type": "\\def",
+    "named": false
+  },
+  {
+    "type": "\\definecolor",
+    "named": false
+  },
+  {
+    "type": "\\definecolorset",
+    "named": false
+  },
+  {
+    "type": "\\documentclass",
+    "named": false
+  },
+  {
+    "type": "\\end",
+    "named": false
+  },
+  {
+    "type": "\\eqref",
+    "named": false
+  },
+  {
+    "type": "\\fi",
+    "named": false
+  },
+  {
+    "type": "\\fnotecite",
+    "named": false
+  },
+  {
+    "type": "\\footcite",
+    "named": false
+  },
+  {
+    "type": "\\footcitetext",
+    "named": false
+  },
+  {
+    "type": "\\footfullcite",
+    "named": false
+  },
+  {
+    "type": "\\ftvolcite",
+    "named": false
+  },
+  {
+    "type": "\\fullcite",
+    "named": false
+  },
+  {
+    "type": "\\fvolcite",
+    "named": false
+  },
+  {
+    "type": "\\gls",
+    "named": false
+  },
+  {
+    "type": "\\glsdesc",
+    "named": false
+  },
+  {
+    "type": "\\glsdisp",
+    "named": false
+  },
+  {
+    "type": "\\glsentryfullpl",
+    "named": false
+  },
+  {
+    "type": "\\glsentrylong",
+    "named": false
+  },
+  {
+    "type": "\\glsentrylongpl",
+    "named": false
+  },
+  {
+    "type": "\\glsentryshort",
+    "named": false
+  },
+  {
+    "type": "\\glsentryshortpl",
+    "named": false
+  },
+  {
+    "type": "\\glsfirst",
+    "named": false
+  },
+  {
+    "type": "\\glsfirstplural",
+    "named": false
+  },
+  {
+    "type": "\\glslink",
+    "named": false
+  },
+  {
+    "type": "\\glsname",
+    "named": false
+  },
+  {
+    "type": "\\glspl",
+    "named": false
+  },
+  {
+    "type": "\\glsplural",
+    "named": false
+  },
+  {
+    "type": "\\glssymbol",
+    "named": false
+  },
+  {
+    "type": "\\glstext",
+    "named": false
+  },
+  {
+    "type": "\\glsuseri",
+    "named": false
+  },
+  {
+    "type": "\\glsuserii",
+    "named": false
+  },
+  {
+    "type": "\\glsuseriii",
+    "named": false
+  },
+  {
+    "type": "\\glsuseriv",
+    "named": false
+  },
+  {
+    "type": "\\glsuserv",
+    "named": false
+  },
+  {
+    "type": "\\glsuservi",
+    "named": false
+  },
+  {
+    "type": "\\href",
+    "named": false
+  },
+  {
+    "type": "\\iffalse",
+    "named": false
+  },
+  {
+    "type": "\\import",
+    "named": false
+  },
+  {
+    "type": "\\include",
+    "named": false
+  },
+  {
+    "type": "\\includefrom",
+    "named": false
+  },
+  {
+    "type": "\\includegraphics",
+    "named": false
+  },
+  {
+    "type": "\\includeinkscape",
+    "named": false
+  },
+  {
+    "type": "\\includesvg",
+    "named": false
+  },
+  {
+    "type": "\\input",
+    "named": false
+  },
+  {
+    "type": "\\inputfrom",
+    "named": false
+  },
+  {
+    "type": "\\intertext",
+    "named": false
+  },
+  {
+    "type": "\\item",
+    "named": false
+  },
+  {
+    "type": "\\item*",
+    "named": false
+  },
+  {
+    "type": "\\label",
+    "named": false
+  },
+  {
+    "type": "\\labelcpageref",
+    "named": false
+  },
+  {
+    "type": "\\labelcref",
+    "named": false
+  },
+  {
+    "type": "\\lcnamecref",
+    "named": false
+  },
+  {
+    "type": "\\lcnamecrefs",
+    "named": false
+  },
+  {
+    "type": "\\left",
+    "named": false
+  },
+  {
+    "type": "\\let",
+    "named": false
+  },
+  {
+    "type": "\\nameCref",
+    "named": false
+  },
+  {
+    "type": "\\nameCrefs",
+    "named": false
+  },
+  {
+    "type": "\\namecref",
+    "named": false
+  },
+  {
+    "type": "\\namecrefs",
+    "named": false
+  },
+  {
+    "type": "\\newacronym",
+    "named": false
+  },
+  {
+    "type": "\\newcommand",
+    "named": false
+  },
+  {
+    "type": "\\newcommand*",
+    "named": false
+  },
+  {
+    "type": "\\newenvironment",
+    "named": false
+  },
+  {
+    "type": "\\newglossaryentry",
+    "named": false
+  },
+  {
+    "type": "\\newlabel",
+    "named": false
+  },
+  {
+    "type": "\\newtheorem",
+    "named": false
+  },
+  {
+    "type": "\\newtheorem*",
+    "named": false
+  },
+  {
+    "type": "\\nocite",
+    "named": false
+  },
+  {
+    "type": "\\notecite",
+    "named": false
+  },
+  {
+    "type": "\\pagecolor",
+    "named": false
+  },
+  {
+    "type": "\\pageref",
+    "named": false
+  },
+  {
+    "type": "\\paragraph",
+    "named": false
+  },
+  {
+    "type": "\\paragraph*",
+    "named": false
+  },
+  {
+    "type": "\\parencite",
+    "named": false
+  },
+  {
+    "type": "\\parencite*",
+    "named": false
+  },
+  {
+    "type": "\\part",
+    "named": false
+  },
+  {
+    "type": "\\part*",
+    "named": false
+  },
+  {
+    "type": "\\pnotecite",
+    "named": false
+  },
+  {
+    "type": "\\pvolcite",
+    "named": false
+  },
+  {
+    "type": "\\ref",
+    "named": false
+  },
+  {
+    "type": "\\renewcommand",
+    "named": false
+  },
+  {
+    "type": "\\renewcommand*",
+    "named": false
+  },
+  {
+    "type": "\\renewenvironment",
+    "named": false
+  },
+  {
+    "type": "\\right",
+    "named": false
+  },
+  {
+    "type": "\\section",
+    "named": false
+  },
+  {
+    "type": "\\section*",
+    "named": false
+  },
+  {
+    "type": "\\shortintertext",
+    "named": false
+  },
+  {
+    "type": "\\smartcite",
+    "named": false
+  },
+  {
+    "type": "\\subfile",
+    "named": false
+  },
+  {
+    "type": "\\subfileinclude",
+    "named": false
+  },
+  {
+    "type": "\\subimport",
+    "named": false
+  },
+  {
+    "type": "\\subimportfrom",
+    "named": false
+  },
+  {
+    "type": "\\subincludefrom",
+    "named": false
+  },
+  {
+    "type": "\\subparagraph",
+    "named": false
+  },
+  {
+    "type": "\\subparagraph*",
+    "named": false
+  },
+  {
+    "type": "\\subsection",
+    "named": false
+  },
+  {
+    "type": "\\subsection*",
+    "named": false
+  },
+  {
+    "type": "\\subsubsection",
+    "named": false
+  },
+  {
+    "type": "\\subsubsection*",
+    "named": false
+  },
+  {
+    "type": "\\supercite",
+    "named": false
+  },
+  {
+    "type": "\\svolcite",
+    "named": false
+  },
+  {
+    "type": "\\text",
+    "named": false
+  },
+  {
+    "type": "\\textcite",
+    "named": false
+  },
+  {
+    "type": "\\textcolor",
+    "named": false
+  },
+  {
+    "type": "\\title",
+    "named": false
+  },
+  {
+    "type": "\\tvolcite",
+    "named": false
+  },
+  {
+    "type": "\\url",
+    "named": false
+  },
+  {
+    "type": "\\usepackage",
+    "named": false
+  },
+  {
+    "type": "\\usepgflibrary",
+    "named": false
+  },
+  {
+    "type": "\\usetikzlibrary",
+    "named": false
+  },
+  {
+    "type": "\\verbatiminput",
+    "named": false
+  },
+  {
+    "type": "\\volcite",
+    "named": false
+  },
+  {
+    "type": "\\vref",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "^",
+    "named": false
+  },
+  {
+    "type": "_",
+    "named": false
+  },
+  {
+    "type": "argc",
+    "named": true
+  },
+  {
+    "type": "command_name",
+    "named": true
+  },
+  {
+    "type": "comment",
+    "named": true
+  },
+  {
+    "type": "letter",
+    "named": true
+  },
+  {
+    "type": "line_comment",
+    "named": true
+  },
+  {
+    "type": "path",
+    "named": true
+  },
+  {
+    "type": "placeholder",
+    "named": true
+  },
+  {
+    "type": "source_code",
+    "named": true
+  },
+  {
+    "type": "uri",
+    "named": true
+  },
+  {
+    "type": "word",
+    "named": true
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "|",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]


### PR DESCRIPTION
Having `grammar.json` checked in will reduce the dependence on `Node.js` when compiling the grammar in the future.