### PR TITLE
Properly support definition commands from xparse

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1139,6 +1139,35 @@
         }
       ]
     },
+    "curly_group_spec": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_text_content"
+              },
+              {
+                "type": "STRING",
+                "value": "="
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
     "curly_group_text_list": {
       "type": "SEQ",
       "members": [
@@ -5073,6 +5102,19 @@
       ]
     },
     "new_command_definition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_new_command_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_newer_command_definition"
+        }
+      ]
+    },
+    "_new_command_definition": {
       "type": "SEQ",
       "members": [
         {
@@ -5099,6 +5141,14 @@
               },
               {
                 "type": "STRING",
+                "value": "\\providecommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\providecommand*"
+              },
+              {
+                "type": "STRING",
                 "value": "\\DeclareRobustCommand"
               },
               {
@@ -5112,38 +5162,6 @@
               {
                 "type": "STRING",
                 "value": "\\DeclareMathOperator*"
-              },
-              {
-                "type": "STRING",
-                "value": "\\NewDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\RenewDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\ProvideDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\DeclareDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\NewExpandableDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\RenewExpandableDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\ProvideExpandableDocumentCommand"
-              },
-              {
-                "type": "STRING",
-                "value": "\\DeclareExpandableDocumentCommand"
               }
             ]
           }
@@ -5152,8 +5170,17 @@
           "type": "FIELD",
           "name": "declaration",
           "content": {
-            "type": "SYMBOL",
-            "name": "curly_group_command_name"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group_command_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_name"
+              }
+            ]
           }
         },
         {
@@ -5202,6 +5229,89 @@
           }
         }
       ]
+    },
+    "_newer_command_definition": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\NewDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\RenewDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\ProvideDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\DeclareDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\NewExpandableDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\RenewExpandableDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\ProvideExpandableDocumentCommand"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\DeclareExpandableDocumentCommand"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "declaration",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "curly_group_command_name"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "command_name"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "spec",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_spec"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "implementation",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group"
+            }
+          }
+        ]
+      }
     },
     "old_command_definition": {
       "type": "SEQ",
@@ -5489,6 +5599,19 @@
       }
     },
     "environment_definition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_environment_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_newer_environment_definition"
+        }
+      ]
+    },
+    "_environment_definition": {
       "type": "SEQ",
       "members": [
         {
@@ -5504,7 +5627,61 @@
               {
                 "type": "STRING",
                 "value": "\\renewenvironment"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argc",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group_argc"
               },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "begin",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_impl"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "end",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_impl"
+          }
+        }
+      ]
+    },
+    "_newer_environment_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
               {
                 "type": "STRING",
                 "value": "\\NewDocumentEnvironment"
@@ -5534,18 +5711,10 @@
         },
         {
           "type": "FIELD",
-          "name": "argc",
+          "name": "spec",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "brack_group_argc"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "curly_group_spec"
           }
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2371,6 +2371,185 @@
     }
   },
   {
+    "type": "curly_group_spec",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "acronym_definition",
+          "named": true
+        },
+        {
+          "type": "acronym_reference",
+          "named": true
+        },
+        {
+          "type": "author_declaration",
+          "named": true
+        },
+        {
+          "type": "biblatex_include",
+          "named": true
+        },
+        {
+          "type": "bibstyle_include",
+          "named": true
+        },
+        {
+          "type": "bibtex_include",
+          "named": true
+        },
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "caption",
+          "named": true
+        },
+        {
+          "type": "citation",
+          "named": true
+        },
+        {
+          "type": "class_include",
+          "named": true
+        },
+        {
+          "type": "color_definition",
+          "named": true
+        },
+        {
+          "type": "color_reference",
+          "named": true
+        },
+        {
+          "type": "color_set_definition",
+          "named": true
+        },
+        {
+          "type": "curly_group",
+          "named": true
+        },
+        {
+          "type": "displayed_equation",
+          "named": true
+        },
+        {
+          "type": "environment_definition",
+          "named": true
+        },
+        {
+          "type": "generic_command",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_definition",
+          "named": true
+        },
+        {
+          "type": "glossary_entry_reference",
+          "named": true
+        },
+        {
+          "type": "graphics_include",
+          "named": true
+        },
+        {
+          "type": "hyperlink",
+          "named": true
+        },
+        {
+          "type": "import_include",
+          "named": true
+        },
+        {
+          "type": "inkscape_include",
+          "named": true
+        },
+        {
+          "type": "inline_formula",
+          "named": true
+        },
+        {
+          "type": "label_definition",
+          "named": true
+        },
+        {
+          "type": "label_number",
+          "named": true
+        },
+        {
+          "type": "label_reference",
+          "named": true
+        },
+        {
+          "type": "label_reference_range",
+          "named": true
+        },
+        {
+          "type": "latex_include",
+          "named": true
+        },
+        {
+          "type": "let_command_definition",
+          "named": true
+        },
+        {
+          "type": "math_delimiter",
+          "named": true
+        },
+        {
+          "type": "new_command_definition",
+          "named": true
+        },
+        {
+          "type": "old_command_definition",
+          "named": true
+        },
+        {
+          "type": "package_include",
+          "named": true
+        },
+        {
+          "type": "paired_delimiter_definition",
+          "named": true
+        },
+        {
+          "type": "svg_include",
+          "named": true
+        },
+        {
+          "type": "text",
+          "named": true
+        },
+        {
+          "type": "text_mode",
+          "named": true
+        },
+        {
+          "type": "theorem_definition",
+          "named": true
+        },
+        {
+          "type": "tikz_library_import",
+          "named": true
+        },
+        {
+          "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "verbatim_include",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "curly_group_text",
     "named": true,
     "fields": {
@@ -3025,6 +3204,16 @@
         "types": [
           {
             "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "spec": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group_spec",
             "named": true
           }
         ]
@@ -5136,6 +5325,14 @@
             "named": false
           },
           {
+            "type": "\\providecommand",
+            "named": false
+          },
+          {
+            "type": "\\providecommand*",
+            "named": false
+          },
+          {
             "type": "\\renewcommand",
             "named": false
           },
@@ -5149,6 +5346,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "command_name",
+            "named": true
+          },
           {
             "type": "curly_group_command_name",
             "named": true
@@ -5171,6 +5372,16 @@
         "types": [
           {
             "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "spec": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group_spec",
             "named": true
           }
         ]
@@ -9096,6 +9307,14 @@
   },
   {
     "type": "\\pnotecite",
+    "named": false
+  },
+  {
+    "type": "\\providecommand",
+    "named": false
+  },
+  {
+    "type": "\\providecommand*",
     "named": false
   },
   {

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -135,6 +135,67 @@ Command definition with default arg
         (placeholder)))))
 
 ================================================================================
+Command definition without curly braces
+================================================================================
+
+\newcommand\foo[1]{#1}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (new_command_definition
+    (command_name)
+    (brack_group_argc
+      (argc))
+    (curly_group
+      (text
+        (placeholder)))))
+
+================================================================================
+Command definition (xparse)
+================================================================================
+
+\NewDocumentCommand{\foo}{m}{#1}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (new_command_definition
+    (curly_group_command_name
+      (command_name))
+    (curly_group_spec
+      (text
+        (word)))
+    (curly_group
+      (text
+        (placeholder)))))
+
+================================================================================
+Command definition with optional argument (xparse)
+================================================================================
+
+\NewDocumentCommand{\foo}{o{default} m}{#1 #2}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (new_command_definition
+    (curly_group_command_name
+      (command_name))
+    (curly_group_spec
+      (text
+        (word))
+      (curly_group
+        (text
+          (word)))
+      (text
+        (word)))
+    (curly_group
+      (text
+        (placeholder)
+        (placeholder)))))
+
+================================================================================
 Author command
 ================================================================================
 


### PR DESCRIPTION
Additionally, handle command definition without curly braces around the defined command name.

Fixes #129