### PR TITLE
Better color reference

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1182,12 +1182,21 @@ module.exports = grammar({
       ),
 
     color_reference: $ =>
-      seq(
-        field(
-          'command',
-          choice('\\color', '\\colorbox', '\\textcolor', '\\pagecolor'),
+      prec.right(
+        seq(
+          field(
+            'command',
+            choice('\\color', '\\pagecolor', '\\textcolor', '\\mathcolor','\\colorbox'),
+          ),
+          choice(
+            field('name', $.curly_group_text),
+            seq(
+              field('model', $.brack_group_text),
+              field('spec', $.curly_group),
+            ),
+          ),
+          optional(field('text', $.curly_group)),
         ),
-        field('name', $.curly_group_text),
       ),
 
     tikz_library_import: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6489,42 +6489,92 @@
       ]
     },
     "color_reference": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "command",
-          "content": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "\\color"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\pagecolor"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\textcolor"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\mathcolor"
+                },
+                {
+                  "type": "STRING",
+                  "value": "\\colorbox"
+                }
+              ]
+            }
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "\\color"
+                "type": "FIELD",
+                "name": "name",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "curly_group_text"
+                }
               },
               {
-                "type": "STRING",
-                "value": "\\colorbox"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "model",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "brack_group_text"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "spec",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "curly_group"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "text",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "curly_group"
+                }
               },
               {
-                "type": "STRING",
-                "value": "\\textcolor"
-              },
-              {
-                "type": "STRING",
-                "value": "\\pagecolor"
+                "type": "BLANK"
               }
             ]
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "curly_group_text"
-          }
-        }
-      ]
+        ]
+      }
     },
     "tikz_library_import": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1710,6 +1710,10 @@
             "named": false
           },
           {
+            "type": "\\mathcolor",
+            "named": false
+          },
+          {
             "type": "\\pagecolor",
             "named": false
           },
@@ -1719,12 +1723,42 @@
           }
         ]
       },
+      "model": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_text",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "curly_group_text",
+            "named": true
+          }
+        ]
+      },
+      "spec": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "curly_group",
             "named": true
           }
         ]
@@ -9219,6 +9253,10 @@
   },
   {
     "type": "\\let",
+    "named": false
+  },
+  {
+    "type": "\\mathcolor",
     "named": false
   },
   {


### PR DESCRIPTION
- add `\mathcolor`
- support directly passing color scheme and spec
- (optionally) include following argument