### PR TITLE
Implement *Copy macros

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -911,7 +911,7 @@ module.exports = grammar({
       ),
 
     new_command_definition: $ =>
-      choice($._new_command_definition, $._newer_command_definition),
+      choice($._new_command_definition, $._newer_command_definition, $._new_command_copy),
 
     _new_command_definition: $ =>
       seq(
@@ -941,25 +941,37 @@ module.exports = grammar({
       ),
 
     _newer_command_definition: $ =>
-      prec.right(
-        seq(
-          field(
-            'command',
-            choice(
-              '\\NewDocumentCommand',
-              '\\RenewDocumentCommand',
-              '\\ProvideDocumentCommand',
-              '\\DeclareDocumentCommand',
-              '\\NewExpandableDocumentCommand',
-              '\\RenewExpandableDocumentCommand',
-              '\\ProvideExpandableDocumentCommand',
-              '\\DeclareExpandableDocumentCommand',
-            ),
+      seq(
+        field(
+          'command',
+          choice(
+            '\\NewDocumentCommand',
+            '\\RenewDocumentCommand',
+            '\\ProvideDocumentCommand',
+            '\\DeclareDocumentCommand',
+            '\\NewExpandableDocumentCommand',
+            '\\RenewExpandableDocumentCommand',
+            '\\ProvideExpandableDocumentCommand',
+            '\\DeclareExpandableDocumentCommand',
           ),
-          field('declaration', choice($.curly_group_command_name, $.command_name)),
-          field('spec', $.curly_group_spec),
-          field('implementation', $.curly_group),
         ),
+        field('declaration', choice($.curly_group_command_name, $.command_name)),
+        field('spec', $.curly_group_spec),
+        field('implementation', $.curly_group),
+      ),
+
+    _new_command_copy: $ =>
+      seq(
+        field(
+          'command',
+          choice(
+            '\\NewCommandCopy',
+            '\\RenewCommandCopy',
+            '\\DeclareCommandCopy',
+          ),
+        ),
+        field('declaration', choice($.curly_group_command_name, $.command_name)),
+        field('implementation', $.curly_group_command_name),
       ),
 
     old_command_definition: $ =>
@@ -989,7 +1001,7 @@ module.exports = grammar({
       ),
 
     environment_definition: $ =>
-      choice($._environment_definition, $._newer_environment_definition),
+      choice($._environment_definition, $._newer_environment_definition, $._new_environment_copy),
 
     _environment_definition: $ =>
       seq(
@@ -1021,6 +1033,20 @@ module.exports = grammar({
         field('spec', $.curly_group_spec),
         field('begin', $.curly_group_impl),
         field('end', $.curly_group_impl),
+      ),
+
+    _new_environment_copy: $ =>
+      seq(
+        field(
+          'command',
+          choice(
+            '\\NewEnvironmentCopy',
+            '\\RenewEnvironmentCopy',
+            '\\DeclareEnvironmentCopy',
+          ),
+        ),
+        field('name', $.curly_group_text),
+        field('name', $.curly_group_text),
       ),
 
     glossary_entry_definition: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5309,6 +5309,10 @@
         {
           "type": "SYMBOL",
           "name": "_newer_command_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_new_command_copy"
         }
       ]
     },
@@ -5429,87 +5433,134 @@
       ]
     },
     "_newer_command_definition": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "command",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "\\NewDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\RenewDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\ProvideDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\DeclareDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\NewExpandableDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\RenewExpandableDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\ProvideExpandableDocumentCommand"
-                },
-                {
-                  "type": "STRING",
-                  "value": "\\DeclareExpandableDocumentCommand"
-                }
-              ]
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "declaration",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "curly_group_command_name"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "command_name"
-                }
-              ]
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "spec",
-            "content": {
-              "type": "SYMBOL",
-              "name": "curly_group_spec"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "implementation",
-            "content": {
-              "type": "SYMBOL",
-              "name": "curly_group"
-            }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\NewDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ProvideDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\NewExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\ProvideExpandableDocumentCommand"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareExpandableDocumentCommand"
+              }
+            ]
           }
-        ]
-      }
+        },
+        {
+          "type": "FIELD",
+          "name": "declaration",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group_command_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_name"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "spec",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_spec"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "implementation",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "_new_command_copy": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\NewCommandCopy"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewCommandCopy"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareCommandCopy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "declaration",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group_command_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "command_name"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "implementation",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_command_name"
+          }
+        }
+      ]
     },
     "old_command_definition": {
       "type": "SEQ",
@@ -5683,6 +5734,10 @@
         {
           "type": "SYMBOL",
           "name": "_newer_environment_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_new_environment_copy"
         }
       ]
     },
@@ -5806,6 +5861,48 @@
           "content": {
             "type": "SYMBOL",
             "name": "curly_group_impl"
+          }
+        }
+      ]
+    },
+    "_new_environment_copy": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\NewEnvironmentCopy"
+              },
+              {
+                "type": "STRING",
+                "value": "\\RenewEnvironmentCopy"
+              },
+              {
+                "type": "STRING",
+                "value": "\\DeclareEnvironmentCopy"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_text"
           }
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3184,7 +3184,7 @@
       },
       "begin": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "curly_group_impl",
@@ -3201,7 +3201,15 @@
             "named": false
           },
           {
+            "type": "\\DeclareEnvironmentCopy",
+            "named": false
+          },
+          {
             "type": "\\NewDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\NewEnvironmentCopy",
             "named": false
           },
           {
@@ -3210,6 +3218,10 @@
           },
           {
             "type": "\\RenewDocumentEnvironment",
+            "named": false
+          },
+          {
+            "type": "\\RenewEnvironmentCopy",
             "named": false
           },
           {
@@ -3224,7 +3236,7 @@
       },
       "end": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "curly_group_impl",
@@ -3233,7 +3245,7 @@
         ]
       },
       "name": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -5303,6 +5315,10 @@
         "required": true,
         "types": [
           {
+            "type": "\\DeclareCommandCopy",
+            "named": false
+          },
+          {
             "type": "\\DeclareDocumentCommand",
             "named": false
           },
@@ -5327,6 +5343,10 @@
             "named": false
           },
           {
+            "type": "\\NewCommandCopy",
+            "named": false
+          },
+          {
             "type": "\\NewDocumentCommand",
             "named": false
           },
@@ -5340,6 +5360,10 @@
           },
           {
             "type": "\\ProvideExpandableDocumentCommand",
+            "named": false
+          },
+          {
+            "type": "\\RenewCommandCopy",
             "named": false
           },
           {
@@ -5406,6 +5430,10 @@
         "types": [
           {
             "type": "curly_group",
+            "named": true
+          },
+          {
+            "type": "curly_group_command_name",
             "named": true
           }
         ]
@@ -8500,11 +8528,19 @@
     "named": false
   },
   {
+    "type": "\\DeclareCommandCopy",
+    "named": false
+  },
+  {
     "type": "\\DeclareDocumentCommand",
     "named": false
   },
   {
     "type": "\\DeclareDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\DeclareEnvironmentCopy",
     "named": false
   },
   {
@@ -8672,11 +8708,19 @@
     "named": false
   },
   {
+    "type": "\\NewCommandCopy",
+    "named": false
+  },
+  {
     "type": "\\NewDocumentCommand",
     "named": false
   },
   {
     "type": "\\NewDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\NewEnvironmentCopy",
     "named": false
   },
   {
@@ -8712,11 +8756,19 @@
     "named": false
   },
   {
+    "type": "\\RenewCommandCopy",
+    "named": false
+  },
+  {
     "type": "\\RenewDocumentCommand",
     "named": false
   },
   {
     "type": "\\RenewDocumentEnvironment",
+    "named": false
+  },
+  {
+    "type": "\\RenewEnvironmentCopy",
     "named": false
   },
   {

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -196,6 +196,21 @@ Command definition with optional argument (xparse)
         (placeholder)))))
 
 ================================================================================
+Command copy (of command defined in grammar which requires a following node)
+================================================================================
+
+\NewCommandCopy{\foo}{\ref}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (new_command_definition
+    (curly_group_command_name
+      (command_name))
+    (curly_group_command_name
+      (command_name))))
+
+================================================================================
 Author command
 ================================================================================
 


### PR DESCRIPTION
This completes the implementation of all command/environment definition macros which are provided by LaTeX kernel and described in https://ctan.org/pkg/usrguide.

Fixes #124.