### PR TITLE
Support argument placeholders for nested command definition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -386,7 +386,7 @@ module.exports = grammar({
 
     word: $ => /[^\s\\%\{\},\$\[\]\(\)=\#&_\^\-\+\/\*]+/,
 
-    placeholder: $ => /#\d/,
+    placeholder: $ => /#+\d/,
 
     delimiter: $ => /&/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1673,7 +1673,7 @@
     },
     "placeholder": {
       "type": "PATTERN",
-      "value": "#\\d"
+      "value": "#+\\d"
     },
     "delimiter": {
       "type": "PATTERN",

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -196,6 +196,35 @@ Command definition with optional argument (xparse)
         (placeholder)))))
 
 ================================================================================
+Nested command definition with arguments
+================================================================================
+\NewDocumentCommand{\foo}{m}{
+    \DeclareDocumentCommand{\bar}{m}{#1, ##1}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (new_command_definition
+    (curly_group_command_name
+      (command_name))
+    (curly_group_spec
+      (text
+        (word)))
+    (curly_group
+      (new_command_definition
+        (curly_group_command_name
+          (command_name))
+        (curly_group_spec
+          (text
+            (word)))
+        (curly_group
+          (text
+            (placeholder))
+          (text
+            (placeholder)))))))
+
+================================================================================
 Command copy (of command defined in grammar which requires a following node)
 ================================================================================
 


### PR DESCRIPTION
When defining a command within other command, the arguments are accessed by doubling the `#` sign.

Fixes #160.