### PR TITLE
add parser.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -521,5 +521,4 @@ build/
 /bindings/c/*.h
 /bindings/c/tree-sitter-*.pc
 
-src/parser.c
 src/tree_sitter/


### PR DESCRIPTION
when use emacs 29.4 with command M-X `treesit-install-language-gramar`
error msg:
```
⛔ Warning (treesit): Error encountered when installing language grammar: 
(treesit-error Command: cc -fPIC -c -I. parser.c Error output: clang: error: 
no such file or directory: 'parser.c'
clang: error: no input files
)
```

also see renzmann/treesit-auto#116
and renzmann/treesit-auto#118