### PR TITLE
feat: migrate to `tree-sitter.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,16 +50,5 @@
     "prettier": "^3.0.3",
     "tree-sitter-cli": "^0.24.1",
     "prebuildify": "^6.0.0"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.tex",
-      "file-types": [
-        "tex",
-        "sty",
-        "cls",
-        "aux"
-      ]
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,38 @@
+{
+  "grammars": [
+    {
+      "name": "latex",
+      "camelcase": "Latex",
+      "scope": "source.tex",
+      "path": ".",
+      "file-types": [
+        "tex",
+        "sty",
+        "cls",
+        "aux"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.4.0",
+    "license": "MIT",
+    "description": "LaTeX grammar for the tree-sitter parsing library",
+    "authors": [
+      {
+        "name": "Patrick Förster",
+        "email": "patrick.foerster@outlook.de"
+      }
+    ],
+    "links": {
+      "repository": "git+https://github.com/latex-lsp/tree-sitter-latex.git"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Hey 👋 I'm putting up this PR because this file will be a requirement in 0.25, and this is one of the few remaining grammars out there that hasn't migrated, thanks.