### PR TITLE
Todo and changes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -665,6 +665,7 @@ module.exports = grammar({
         $.color_reference,
         $.tikz_library_import,
         $.hyperlink,
+        $.changes_replaced,
         $.generic_command,
       ),
 
@@ -1272,6 +1273,13 @@ module.exports = grammar({
           field('uri', $.curly_group_uri),
           field('label', optional($.curly_group)),
         ),
+      ),
+
+    changes_replaced: $ =>
+      seq(
+        field('command', '\\replaced'),
+        field('text_added', $.curly_group),
+        field('text_deleted', $.curly_group)
       ),
   },
 });

--- a/grammar.js
+++ b/grammar.js
@@ -666,8 +666,18 @@ module.exports = grammar({
         $.tikz_library_import,
         $.hyperlink,
         $.changes_replaced,
+        $.todo,
         $.generic_command,
       ),
+
+    todo: $ =>
+      seq(
+        field('command', $.todo_command_name),
+        field('options', optional($.brack_group)),
+        field('arg', $.curly_group)
+      ),
+
+    todo_command_name: $ => /\\([a-zA-Z]?[a-zA-Z]?todo)/,
 
     generic_command: $ =>
       prec.right(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6897,6 +6897,48 @@
             "name": "curly_group"
           }
         }
+      ]
+    },
+    "todo": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "SYMBOL",
+            "name": "todo_command_name"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arg",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "todo_command_name": {
+      "type": "PATTERN",
+      "value": "\\\\([a-zA-Z]?[a-zA-Z]?todo)"
     }
   },
   "extras": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6869,6 +6869,34 @@
           }
         ]
       }
+    },
+    "changes_replaced": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\replaced"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "text_added",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "text_deleted",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -827,6 +827,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "import_include",
           "named": true
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -823,6 +823,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "import_include",
           "named": true
         },


### PR DESCRIPTION
I added support for `\todo` (and custom `\XXtodo`, where XX are initials of whom the todo coresponds to) with an optional arg and the `\replaced` of changes package with two args.

I thought of doing more general `generic_command_opt` and `generic_command_two_args` instead, but based on what else is found in this package, it seems you are interested in more semantic instead of generic information.

The idea is to do in Zed syntax highlighting similar to [latex-syntax](https://marketplace.visualstudio.com/items?itemName=vomout.latex-syntax) for VSCode. See the image. The corresponding changes to zed-latex are at https://github.com/497e0bdf29873/zed-latex, and a few compatible themes at https://github.com/497e0bdf29873/zed-themes. (Currently Zed also requires `parser.c` etc. to be found, so this repository includes a change to restore it. That change should not be found in this PR.)

I'm not exactly sure if I was supposed to add anything to `grammar.json`, or if `grammar.js` is enough. In any case, the regexps for `\XXtodo` seem to require the latter.

![image](https://github.com/user-attachments/assets/a3a10c67-b015-4be9-a6b6-068f0bbe2f13)
