### PR TITLE
feat: add support for tree-sitter 0.25 (still compatible with 0.21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "tree-sitter-cli": "^0.24.1"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.21.0 || ^0.22.0"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@pfoerster/tree-sitter-latex",
   "version": "0.4.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -19,7 +19,7 @@
         "tree-sitter-cli": "^0.24.1"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.0 || ^0.22.0"
+        "tree-sitter": "^0.21.0 || ^0.25.0"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
@@ -129,18 +129,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -157,9 +145,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.57.0.tgz",
-      "integrity": "sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==",
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -169,17 +157,17 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.2.tgz",
-      "integrity": "sha512-9emqXAKhVoNrQ792nLI/wpzPpJ/bj/YXxW0CvAau1+RdGBcCRF1Dmz7719zgVsQNrzHl9Tzn3ImZ4qWFarWL0A==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -234,9 +222,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -249,9 +237,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -293,13 +281,10 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -317,9 +302,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "dependencies": {
         "chownr": "^1.1.1",
@@ -345,20 +330,20 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
+      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.4.tgz",
-      "integrity": "sha512-I4sdtDidnujYL0tR0Re9q0UJt5KrITf2m+GMHjT4LH6IC6kpM6eLzSR7RS36Z4t5ZQBjDHvg2QUJHAWQi3P2TA==",
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.7.tgz",
+      "integrity": "sha512-o4gnE82pVmMMhJbWwD6+I9yr4lXii5Ci5qEQ2pFpUbVy1YiD8cizTJaqdcznA0qEbo7l2OneI1GocChPrI4YGQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -378,262 +363,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    }
-  },
-  "dependencies": {
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
-    },
-    "node-abi": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.57.0.tgz",
-      "integrity": "sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.3.5"
-      }
-    },
-    "node-addon-api": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.2.tgz",
-      "integrity": "sha512-9emqXAKhVoNrQ792nLI/wpzPpJ/bj/YXxW0CvAau1+RdGBcCRF1Dmz7719zgVsQNrzHl9Tzn3ImZ4qWFarWL0A=="
-    },
-    "node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw=="
-    },
-    "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
-    },
-    "prebuildify": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
-      "integrity": "sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "mkdirp-classic": "^0.5.3",
-        "node-abi": "^3.3.0",
-        "npm-run-path": "^3.1.0",
-        "pump": "^3.0.0",
-        "tar-fs": "^2.1.0"
-      }
-    },
-    "prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
-    },
-    "semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "peer": true,
-      "requires": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
-      }
-    },
-    "tree-sitter-cli": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.4.tgz",
-      "integrity": "sha512-I4sdtDidnujYL0tR0Re9q0UJt5KrITf2m+GMHjT4LH6IC6kpM6eLzSR7RS36Z4t5ZQBjDHvg2QUJHAWQi3P2TA==",
-      "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.1"
+    "tree-sitter": "^0.21.0 || ^0.22.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0 || ^0.22.0"
+    "tree-sitter": "^0.21.0 || ^0.25.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4257,9 +4257,58 @@
         },
         {
           "type": "SYMBOL",
+          "name": "changes_replaced"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo"
+        },
+        {
+          "type": "SYMBOL",
           "name": "generic_command"
         }
       ]
+    },
+    "todo": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "SYMBOL",
+            "name": "todo_command_name"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "options",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "brack_group"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arg",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group"
+          }
+        }
+      ]
+    },
+    "todo_command_name": {
+      "type": "PATTERN",
+      "value": "\\\\([a-zA-Z]?[a-zA-Z]?todo)"
     },
     "generic_command": {
       "type": "PREC_RIGHT",
@@ -6899,47 +6948,6 @@
           }
         }
       ]
-    },
-    "todo": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "command",
-          "content": {
-            "type": "SYMBOL",
-            "name": "todo_command_name"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "options",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "brack_group"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "arg",
-          "content": {
-            "type": "SYMBOL",
-            "name": "curly_group"
-          }
-        }
-      ]
-    },
-    "todo_command_name": {
-      "type": "PATTERN",
-      "value": "\\\\([a-zA-Z]?[a-zA-Z]?todo)"
     }
   },
   "extras": [
@@ -7005,6 +7013,5 @@
     }
   ],
   "inline": [],
-  "supertypes": [],
-  "reserved": {}
+  "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -372,6 +372,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -501,6 +505,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -763,6 +771,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -820,14 +832,6 @@
         },
         {
           "type": "hyperlink",
-          "named": true
-        },
-        {
-          "type": "changes_replaced",
-          "named": true
-        },
-        {
-          "type": "todo",
           "named": true
         },
         {
@@ -939,6 +943,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -1034,6 +1042,42 @@
     }
   },
   {
+    "type": "changes_replaced",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\replaced",
+            "named": false
+          }
+        ]
+      },
+      "text_added": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "text_deleted": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "chapter",
     "named": true,
     "fields": {
@@ -1122,6 +1166,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -1314,6 +1362,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -1924,6 +1976,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "chapter",
           "named": true
         },
@@ -2124,6 +2180,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -2226,6 +2286,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -2355,6 +2419,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -2453,6 +2521,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -2582,6 +2654,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -2688,6 +2764,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "chapter",
           "named": true
         },
@@ -2885,6 +2965,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -2998,6 +3082,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -3163,6 +3251,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -3370,6 +3462,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "chapter",
           "named": true
         },
@@ -3567,6 +3663,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -4054,6 +4154,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "chapter",
           "named": true
         },
@@ -4251,6 +4355,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -4854,6 +4962,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "chapter",
           "named": true
         },
@@ -5054,6 +5166,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -5131,6 +5247,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -5299,6 +5419,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -5747,6 +5871,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -5923,6 +6051,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -6022,6 +6154,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -6218,6 +6354,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -6431,6 +6571,10 @@
           "named": true
         },
         {
+          "type": "changes_replaced",
+          "named": true
+        },
+        {
           "type": "citation",
           "named": true
         },
@@ -6619,6 +6763,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -6676,6 +6824,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -6879,6 +7031,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -6970,6 +7126,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -7145,6 +7305,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -7260,6 +7424,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -7447,6 +7615,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -7538,6 +7710,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -7721,6 +7897,10 @@
           "named": true
         },
         {
+          "type": "todo",
+          "named": true
+        },
+        {
           "type": "verbatim_environment",
           "named": true
         },
@@ -7829,6 +8009,10 @@
           },
           {
             "type": "caption",
+            "named": true
+          },
+          {
+            "type": "changes_replaced",
             "named": true
           },
           {
@@ -7957,6 +8141,10 @@
           },
           {
             "type": "title_declaration",
+            "named": true
+          },
+          {
+            "type": "todo",
             "named": true
           },
           {
@@ -8140,6 +8328,42 @@
     }
   },
   {
+    "type": "todo",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group",
+            "named": true
+          }
+        ]
+      },
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "todo_command_name",
+            "named": true
+          }
+        ]
+      },
+      "options": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "value",
     "named": true,
     "fields": {},
@@ -8181,6 +8405,10 @@
         },
         {
           "type": "caption",
+          "named": true
+        },
+        {
+          "type": "changes_replaced",
           "named": true
         },
         {
@@ -8313,6 +8541,10 @@
         },
         {
           "type": "title_declaration",
+          "named": true
+        },
+        {
+          "type": "todo",
           "named": true
         },
         {
@@ -9549,6 +9781,10 @@
     "named": false
   },
   {
+    "type": "\\replaced",
+    "named": false
+  },
+  {
     "type": "\\right",
     "named": false
   },
@@ -9706,8 +9942,7 @@
   },
   {
     "type": "line_comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "path",
@@ -9719,6 +9954,10 @@
   },
   {
     "type": "source_code",
+    "named": true
+  },
+  {
+    "type": "todo_command_name",
     "named": true
   },
   {


### PR DESCRIPTION
## Motivation
<p><code inline="">tree-sitter</code> 0.25 is the current stable release, but this grammar still restricted consumers to 0.21. On npm ≥ 7 that causes an <code inline="">ERESOLVE</code> conflict for projects already upgrading to 0.25.<br>
This PR widens the peer-dependency range so users can choose either version without warnings or build failures.</p>
<h3>What’s changed</h3>

File | Change
-- | --
package.json | * peerDependencies: tree-sitter → ^0.21.0 \|\| ^0.25.0*
src/grammar.json<br>src/node-types.json | Regenerated with tree-sitter-cli 0.25 to match the new ABI
package-lock.json | Auto-updated by npm ci

## Verification
- Built and tested successfully on <strong>Node 20</strong> and <strong>Node 24</strong>

## Notes
- Versions 0.22–0.24 introduced internal changes and are <strong>not</strong> included here to keep the range minimal.
- If you prefer not to ship generated files, let me know and I’ll drop them from the PR.