### PR TITLE
fix!: label numbers and reference ranges

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -931,14 +931,14 @@ module.exports = grammar({
             '\\Cpagerefrange',
           ),
         ),
-        field('from', $.curly_group_text),
-        field('to', $.curly_group_text),
+        field('from', $.curly_group_label),
+        field('to', $.curly_group_label),
       ),
 
     label_number: $ =>
       seq(
         field('command', '\\newlabel'),
-        field('name', $.curly_group_text),
+        field('name', $.curly_group_label),
         field('number', $.curly_group),
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5410,7 +5410,7 @@
           "name": "from",
           "content": {
             "type": "SYMBOL",
-            "name": "curly_group_text"
+            "name": "curly_group_label"
           }
         },
         {
@@ -5418,7 +5418,7 @@
           "name": "to",
           "content": {
             "type": "SYMBOL",
-            "name": "curly_group_text"
+            "name": "curly_group_label"
           }
         }
       ]
@@ -5439,7 +5439,7 @@
           "name": "name",
           "content": {
             "type": "SYMBOL",
-            "name": "curly_group_text"
+            "name": "curly_group_label"
           }
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4475,7 +4475,7 @@
         "required": true,
         "types": [
           {
-            "type": "curly_group_text",
+            "type": "curly_group_label",
             "named": true
           }
         ]
@@ -4657,7 +4657,7 @@
         "required": true,
         "types": [
           {
-            "type": "curly_group_text",
+            "type": "curly_group_label",
             "named": true
           }
         ]
@@ -4667,7 +4667,7 @@
         "required": true,
         "types": [
           {
-            "type": "curly_group_text",
+            "type": "curly_group_label",
             "named": true
           }
         ]

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -385,3 +385,41 @@ Reference(s), with path separators and colons.
   	(curly_group_label_list
 	  (label))))
 
+================================================================================
+Label creation in auxiliary files
+================================================================================
+
+\newlabel{chapter/foo}{{1}{1}{Foo}{chapter.1}{}}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (label_number
+  	(curly_group_label
+	  (label))
+	(curly_group
+		(curly_group
+		  (text (word)))
+		(curly_group
+		  (text (word)))
+		(curly_group
+		  (text (word)))
+		(curly_group
+		  (text (word)))
+		(curly_group))))
+
+================================================================================
+Reference ranges
+================================================================================
+
+\crefrange{foo/bar}{foo:baz}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (label_reference_range
+  	(curly_group_label
+	  (label))
+  	(curly_group_label
+	  (label))))
+


### PR DESCRIPTION
In the PR #207, a new curly_group_label node was created. This updates the label_number and label_reference_range nodes to use that node type.