### PR TITLE
feat(counters): add creation/setting/typesetting

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1112,6 +1112,48 @@
         }
       ]
     },
+    "curly_group_word": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "SYMBOL",
+            "name": "word"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "curly_group_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "value_literal"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
     "curly_group_spec": {
       "type": "SEQ",
       "members": [
@@ -1620,6 +1662,27 @@
         }
       ]
     },
+    "brack_group_word": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "FIELD",
+          "name": "word",
+          "content": {
+            "type": "SYMBOL",
+            "name": "word"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
     "brack_group_argc": {
       "type": "SEQ",
       "members": [
@@ -1750,6 +1813,10 @@
     "placeholder": {
       "type": "PATTERN",
       "value": "#+\\d"
+    },
+    "value_literal": {
+      "type": "PATTERN",
+      "value": "(\\d+\\.)?\\d+"
     },
     "delimiter": {
       "type": "PATTERN",
@@ -4260,6 +4327,38 @@
         },
         {
           "type": "SYMBOL",
+          "name": "counter_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_within_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_without_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_addition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_increment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "counter_typesetting"
+        },
+        {
+          "type": "SYMBOL",
           "name": "label_definition"
         },
         {
@@ -4420,6 +4519,313 @@
     "command_name": {
       "type": "PATTERN",
       "value": "\\\\([^\\r\\n]|[@a-zA-Z]+\\*?)?"
+    },
+    "counter_declaration": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "command",
+            "content": {
+              "type": "STRING",
+              "value": "\\newcounter"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "counter",
+            "content": {
+              "type": "SYMBOL",
+              "name": "curly_group_word"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "counterwithin",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "brack_group_word"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "counter_within_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\counterwithin"
+              },
+              {
+                "type": "STRING",
+                "value": "\\counterwithin*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "supercounter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        }
+      ]
+    },
+    "counter_without_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\counterwithout"
+              },
+              {
+                "type": "STRING",
+                "value": "\\counterwithout*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "supercounter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        }
+      ]
+    },
+    "counter_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\value"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        }
+      ]
+    },
+    "counter_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\setcounter"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group_value"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "{"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "counter_value"
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "counter_addition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "STRING",
+            "value": "\\addtocounter"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "curly_group_value"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "counter_value"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "counter_increment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\stepcounter"
+              },
+              {
+                "type": "STRING",
+                "value": "\\refstepcounter"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        }
+      ]
+    },
+    "counter_typesetting": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "command",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\arabic"
+              },
+              {
+                "type": "STRING",
+                "value": "\\alph"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Alph"
+              },
+              {
+                "type": "STRING",
+                "value": "\\roman"
+              },
+              {
+                "type": "STRING",
+                "value": "\\Roman"
+              },
+              {
+                "type": "STRING",
+                "value": "\\fnsymbol"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "counter",
+          "content": {
+            "type": "SYMBOL",
+            "name": "curly_group_word"
+          }
+        }
+      ]
     },
     "title_declaration": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -396,6 +396,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -799,6 +831,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -1006,6 +1070,22 @@
     }
   },
   {
+    "type": "brack_group_word",
+    "named": true,
+    "fields": {
+      "word": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "caption",
     "named": true,
     "fields": {
@@ -1194,6 +1274,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -1928,6 +2040,312 @@
     }
   },
   {
+    "type": "counter_addition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\addtocounter",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "counter_value",
+            "named": true
+          },
+          {
+            "type": "curly_group_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_declaration",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\newcounter",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      },
+      "counterwithin": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "brack_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_definition",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\setcounter",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "counter_value",
+            "named": true
+          },
+          {
+            "type": "curly_group_value",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_increment",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\refstepcounter",
+            "named": false
+          },
+          {
+            "type": "\\stepcounter",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_typesetting",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\Alph",
+            "named": false
+          },
+          {
+            "type": "\\Roman",
+            "named": false
+          },
+          {
+            "type": "\\alph",
+            "named": false
+          },
+          {
+            "type": "\\arabic",
+            "named": false
+          },
+          {
+            "type": "\\fnsymbol",
+            "named": false
+          },
+          {
+            "type": "\\roman",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_value",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\value",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_within_declaration",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\counterwithin",
+            "named": false
+          },
+          {
+            "type": "\\counterwithin*",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      },
+      "supercounter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "counter_without_declaration",
+    "named": true,
+    "fields": {
+      "command": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\\counterwithout",
+            "named": false
+          },
+          {
+            "type": "\\counterwithout*",
+            "named": false
+          }
+        ]
+      },
+      "counter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      },
+      "supercounter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "curly_group_word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "curly_group",
     "named": true,
     "fields": {},
@@ -2005,6 +2423,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -2310,6 +2760,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -2577,6 +3059,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -2748,6 +3262,38 @@
     }
   },
   {
+    "type": "curly_group_value",
+    "named": true,
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "value_literal",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "curly_group_word",
+    "named": true,
+    "fields": {
+      "word": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "displayed_equation",
     "named": true,
     "fields": {},
@@ -2825,6 +3371,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -3139,6 +3717,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -3523,6 +4133,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -4215,6 +4857,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -5026,6 +5700,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -5307,6 +6013,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -5931,6 +6669,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -6218,6 +6988,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -6631,6 +7433,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -6888,6 +7722,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -7189,6 +8055,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -7487,6 +8385,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -7770,6 +8700,38 @@
         },
         {
           "type": "comment_environment",
+          "named": true
+        },
+        {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
           "named": true
         },
         {
@@ -8065,6 +9027,38 @@
           },
           {
             "type": "color_set_definition",
+            "named": true
+          },
+          {
+            "type": "counter_addition",
+            "named": true
+          },
+          {
+            "type": "counter_declaration",
+            "named": true
+          },
+          {
+            "type": "counter_definition",
+            "named": true
+          },
+          {
+            "type": "counter_increment",
+            "named": true
+          },
+          {
+            "type": "counter_typesetting",
+            "named": true
+          },
+          {
+            "type": "counter_value",
+            "named": true
+          },
+          {
+            "type": "counter_within_declaration",
+            "named": true
+          },
+          {
+            "type": "counter_without_declaration",
             "named": true
           },
           {
@@ -8464,6 +9458,38 @@
           "named": true
         },
         {
+          "type": "counter_addition",
+          "named": true
+        },
+        {
+          "type": "counter_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_definition",
+          "named": true
+        },
+        {
+          "type": "counter_increment",
+          "named": true
+        },
+        {
+          "type": "counter_typesetting",
+          "named": true
+        },
+        {
+          "type": "counter_value",
+          "named": true
+        },
+        {
+          "type": "counter_within_declaration",
+          "named": true
+        },
+        {
+          "type": "counter_without_declaration",
+          "named": true
+        },
+        {
           "type": "curly_group",
           "named": true
         },
@@ -8801,6 +9827,10 @@
     "named": false
   },
   {
+    "type": "\\Alph",
+    "named": false
+  },
+  {
     "type": "\\Autocite",
     "named": false
   },
@@ -9117,6 +10147,10 @@
     "named": false
   },
   {
+    "type": "\\Roman",
+    "named": false
+  },
+  {
     "type": "\\Smartcite",
     "named": false
   },
@@ -9234,6 +10268,18 @@
   },
   {
     "type": "\\addsec*",
+    "named": false
+  },
+  {
+    "type": "\\addtocounter",
+    "named": false
+  },
+  {
+    "type": "\\alph",
+    "named": false
+  },
+  {
+    "type": "\\arabic",
     "named": false
   },
   {
@@ -9409,6 +10455,22 @@
     "named": false
   },
   {
+    "type": "\\counterwithin",
+    "named": false
+  },
+  {
+    "type": "\\counterwithin*",
+    "named": false
+  },
+  {
+    "type": "\\counterwithout",
+    "named": false
+  },
+  {
+    "type": "\\counterwithout*",
+    "named": false
+  },
+  {
     "type": "\\cpageref",
     "named": false
   },
@@ -9474,6 +10536,10 @@
   },
   {
     "type": "\\fnotecite",
+    "named": false
+  },
+  {
+    "type": "\\fnsymbol",
     "named": false
   },
   {
@@ -9717,6 +10783,10 @@
     "named": false
   },
   {
+    "type": "\\newcounter",
+    "named": false
+  },
+  {
     "type": "\\newenvironment",
     "named": false
   },
@@ -9801,6 +10871,10 @@
     "named": false
   },
   {
+    "type": "\\refstepcounter",
+    "named": false
+  },
+  {
     "type": "\\renewcommand",
     "named": false
   },
@@ -9821,6 +10895,10 @@
     "named": false
   },
   {
+    "type": "\\roman",
+    "named": false
+  },
+  {
     "type": "\\section",
     "named": false
   },
@@ -9829,11 +10907,19 @@
     "named": false
   },
   {
+    "type": "\\setcounter",
+    "named": false
+  },
+  {
     "type": "\\shortintertext",
     "named": false
   },
   {
     "type": "\\smartcite",
+    "named": false
+  },
+  {
+    "type": "\\stepcounter",
     "named": false
   },
   {
@@ -9925,6 +11011,10 @@
     "named": false
   },
   {
+    "type": "\\value",
+    "named": false
+  },
+  {
     "type": "\\verbatiminput",
     "named": false
   },
@@ -9999,6 +11089,10 @@
   },
   {
     "type": "uri",
+    "named": true
+  },
+  {
+    "type": "value_literal",
     "named": true
   },
   {

--- a/test/corpus/counters.txt
+++ b/test/corpus/counters.txt
@@ -1,0 +1,182 @@
+================================================================================
+Declaring a counter.
+================================================================================
+
+\newcounter{foo}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word))))
+
+================================================================================
+Declaring a counter with a supercounter.
+================================================================================
+
+\newcounter{foo}[chapter]
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word))
+	(brack_group_word
+	  (word))))
+
+================================================================================
+Re-parenting a counter within a supercounter.
+================================================================================
+
+\counterwithin{foo}{bar}
+\counterwithin*{foo}{bar}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_within_declaration
+    (curly_group_word
+	  (word))
+	(curly_group_word
+	  (word)))
+  (counter_within_declaration
+    (curly_group_word
+	  (word))
+	(curly_group_word
+	  (word))))
+
+================================================================================
+Breaking the link between a counter and its supercounter.
+================================================================================
+
+\counterwithout{foo}{bar}
+\counterwithout*{foo}{bar}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_without_declaration
+    (curly_group_word
+	  (word))
+	(curly_group_word
+	  (word)))
+  (counter_without_declaration
+    (curly_group_word
+	  (word))
+	(curly_group_word
+	  (word))))
+
+================================================================================
+Getting a counter's value.
+================================================================================
+
+\newcounter{foo}
+\value{foo}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_value
+    (curly_group_word
+	  (word))))
+
+================================================================================
+Setting a counter's value.
+================================================================================
+
+\newcounter{foo}
+\setcounter{foo}{0}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_definition
+    (curly_group_word
+	  (word))
+	(curly_group_value
+	  (value_literal))))
+
+================================================================================
+Setting a counter's value from another counter.
+================================================================================
+
+\newcounter{foo}
+\newcounter{bar}
+\setcounter{foo}{\value{bar}}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_definition
+    (curly_group_word
+	  (word))
+	(counter_value
+	  (curly_group_word
+        (word)))))
+
+================================================================================
+Stepping over a counter.
+================================================================================
+
+\newcounter{foo}
+\stepcounter{foo}
+\refstepcounter{foo}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_increment
+    (curly_group_word
+	  (word)))
+  (counter_increment
+    (curly_group_word
+	  (word))))
+
+================================================================================
+Typesetting a counter.
+================================================================================
+
+\newcounter{foo}
+\setcounter{foo}{5}
+
+Values: \alph{foo}, \roman{foo}, \arabic{foo}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (counter_declaration
+    (curly_group_word
+	  (word)))
+  (counter_definition
+    (curly_group_word
+	  (word))
+	(curly_group_value
+	  (value_literal)))
+  (text
+    (word)
+	(counter_typesetting
+	 (curly_group_word
+	   (word))))
+	(counter_typesetting
+	 (curly_group_word
+	   (word)))
+	(counter_typesetting
+	 (curly_group_word
+	   (word))))


### PR DESCRIPTION
This also adds tests for the counters. Those are pretty basic, but can at least make sure the grammar works as intended.

As this PR _adds_ new nodes, no queries should break. I've tested it on my local neovim setup and no issues were raised (other than the missing highlights, of course).

For the moment, here are the supported commands:

```tex
% Creating:
\newcounter{cname}
\newcounter{cname}[supercounter]
\conterwithin{cname}{othercname}% And the starred version.
\conterwithout{cname}{othercname}% And the starred version.
% Manipulating:
\setcounter{cname}{value}
\addtocounter{cname}{value}
\stepcounter{cname}
\refstepcounter{cname}
\value{cname}
% Typesetting:
\arabic{cname}
\alph{cname}
\Alph{cname}
\roman{cname}
\Roman{cname}
\fnsymbol{cname}
```

(edit: grammar and spelling mistakes)