### PR TITLE
fix(counters)!: make naming consistent

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -717,7 +717,7 @@ module.exports = grammar({
         seq(
           field('command', '\\newcounter'),
           field('counter', $.curly_group_word),
-          optional(field('counterwithin', $.brack_group_word))
+          optional(field('supercounter', $.brack_group_word))
         )
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4547,7 +4547,7 @@
             "members": [
               {
                 "type": "FIELD",
-                "name": "counterwithin",
+                "name": "supercounter",
                 "content": {
                   "type": "SYMBOL",
                   "name": "brack_group_word"
@@ -4743,8 +4743,25 @@
                 "name": "curly_group_value"
               },
               {
-                "type": "SYMBOL",
-                "name": "counter_value"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "{"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "counter_value"
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "}"
+                  }
+                ]
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2064,7 +2064,7 @@
         ]
       },
       "value": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -2074,6 +2074,14 @@
           {
             "type": "curly_group_value",
             "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
           }
         ]
       }
@@ -2103,7 +2111,7 @@
           }
         ]
       },
-      "counterwithin": {
+      "supercounter": {
         "multiple": false,
         "required": false,
         "types": [


### PR DESCRIPTION
While making the highlight rules for `nvim-treesitter`, I noticed some inconsistent naming between nodes that really should be named similarly.

This is mainly for clarity, but it'd be nice to have it merged so the grammar files are a bit less convoluted to read (and adhere a bit more to LaTeX terminology).